### PR TITLE
Change publishFeedCredentials connection string

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -278,7 +278,7 @@ stages:
                 command: push
                 packagesToPush: '$(Pipeline.Workspace)/Nugets/Microsoft.Kiota.Abstractions.*.nupkg'
                 nuGetFeedType: external
-                publishFeedCredentials: 'microsoftgraph NuGet connection'
+                publishFeedCredentials: 'OpenAPI Nuget Connection'
             - task: GitHubRelease@1
               displayName: 'GitHub release (create)'
               inputs:


### PR DESCRIPTION
This PR changes the publishFeedCredentials due to Prefix preservations on nuget. 