### PR TITLE
Validate SemVer 2 versions on release

### DIFF
--- a/scripts/ValidateProjectVersionUpdated.ps1
+++ b/scripts/ValidateProjectVersionUpdated.ps1
@@ -40,7 +40,7 @@ $currentProjectVersion = [System.Management.Automation.SemanticVersion]"$version
 
 # API is case-sensitive
 $packageName = $packageName.ToLower()
-$url = "https://api.nuget.org/v3/registration3/$packageName/index.json"
+$url = "https://api.nuget.org/v3/registration5-gz-semver2/$packageName/index.json"
 
 # Call the NuGet API for the package and get the current published version.
 Try {


### PR DESCRIPTION
This PR updates the ValidateProjectVersionUpdated.ps1 script to use the NuGet endpoint that supports SemVer 2.0.

At the moment, PRs merged to main are triggering the deploy stage  as the currently used endpoint does not list pre-release packages(which use SemVer 2.0)

References
- https://docs.microsoft.com/en-us/nuget/api/registration-base-url-resource#registrationsbaseurl