### PR TITLE
- fixes a bug where empty query parameters would be passed

### DIFF
--- a/src/Microsoft.Kiota.Abstractions.csproj
+++ b/src/Microsoft.Kiota.Abstractions.csproj
@@ -14,7 +14,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>preview.3</VersionSuffix>
+    <VersionSuffix>preview.4</VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <SignAssembly>false</SignAssembly>
     <DelaySign>false</DelaySign>
@@ -23,7 +23,7 @@
     <!-- Enable this line once we go live to prevent breaking changes -->
     <!-- <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> -->
     <PackageReleaseNotes>
-        - Breaking: simplifies the field deserializers.
+        - Adds support for query parameters name attribute.
     </PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/src/QueryParametersBase.cs
+++ b/src/QueryParametersBase.cs
@@ -22,12 +22,17 @@ namespace Microsoft.Kiota.Abstractions
             if(target == null) throw new ArgumentNullException(nameof(target));
             foreach(var property in this.GetType()
                                         .GetProperties()
-                                        .Where(x => !target.ContainsKey(x.Name)))
+                                        .Select(
+                                            x => (
+                                                Name: x.GetCustomAttributes(false)
+                                                    .OfType<QueryParameterAttribute>()
+                                                    .FirstOrDefault()?.TemplateName ?? x.Name.ToFirstCharacterLowerCase(),
+                                                Value: x.GetValue(this)
+                                            )
+                                        )
+                                        .Where(x => x.Value != null && !target.ContainsKey(x.Name)))
             {
-                var attribute = property.GetCustomAttributes(false)
-                                        .OfType<QueryParameterAttribute>()
-                                        .FirstOrDefault();
-                target.Add(attribute?.TemplateName ?? property.Name.ToFirstCharacterLowerCase(), property.GetValue(this));
+                target.Add(property.Name, property.Value);
             }
         }
     }


### PR DESCRIPTION
I have stopped the release and caught this minor bug in my integration testing.