### PR TITLE
Changes target runtime to netstandard2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.0.0-preview.5] - 2022-04-12
+
+### Changed
+
+- Breaking: Changes target runtime to netstandard2.0
+
 ## [1.0.0-preview.4] - 2022-04-06
 
 ### Added

--- a/src/ApiClientBuilder.cs
+++ b/src/ApiClientBuilder.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Linq;
+using Microsoft.Kiota.Abstractions.Extensions;
 using Microsoft.Kiota.Abstractions.Serialization;
 using Microsoft.Kiota.Abstractions.Store;
 

--- a/src/Microsoft.Kiota.Abstractions.csproj
+++ b/src/Microsoft.Kiota.Abstractions.csproj
@@ -6,7 +6,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>Kiota Abstractions Library for dotnet</AssemblyTitle>
     <Authors>Microsoft</Authors>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota-abstractions-dotnet</RepositoryUrl>
@@ -14,7 +14,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>preview.4</VersionSuffix>
+    <VersionSuffix>preview.5</VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <SignAssembly>false</SignAssembly>
     <DelaySign>false</DelaySign>
@@ -23,7 +23,7 @@
     <!-- Enable this line once we go live to prevent breaking changes -->
     <!-- <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> -->
     <PackageReleaseNotes>
-        - Adds support for query parameters name attribute.
+        - [Breaking] Change target runtime to netstandard 2.0
     </PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/src/RequestInformation.cs
+++ b/src/RequestInformation.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.Kiota.Abstractions.Extensions;
 using Microsoft.Kiota.Abstractions.Serialization;
 using Tavis.UriTemplates;
 

--- a/src/extensions/IDictionaryExtensions.cs
+++ b/src/extensions/IDictionaryExtensions.cs
@@ -1,0 +1,42 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.Kiota.Abstractions.Extensions
+{
+    /// <summary>
+    /// Extension methods for the <see cref="IDictionary"/>
+    /// </summary>
+    public static class IDictionaryExtensions
+    {
+        /// <summary>
+        /// Try to add the element to the <see cref="IDictionary"/> instance.
+        /// </summary>
+        /// <typeparam name="TKey"> The type of the key</typeparam>
+        /// <typeparam name="TValue">The type of the value</typeparam>
+        /// <param name="dictionary">The dictionary to add to.</param>
+        /// <param name="key">The key parameter.</param>
+        /// <param name="value">The value</param>
+        /// <returns>True or False based on whether the item is added successfully</returns>
+        public static bool TryAdd<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue value)
+        {
+            if(dictionary == null)
+            {
+                throw new ArgumentNullException(nameof(dictionary));
+            }
+
+            if(!dictionary.ContainsKey(key))
+            {
+                dictionary.Add(key, value);
+                return true;
+            }
+
+            return false;
+        }
+
+    }
+}

--- a/src/extensions/StringExtensions.cs
+++ b/src/extensions/StringExtensions.cs
@@ -15,6 +15,6 @@ namespace Microsoft.Kiota.Abstractions.Extensions
         /// <param name="input">The string to lowercase.</param>
         /// <returns>The input string with the first letter lowered.</returns>
         public static string ToFirstCharacterLowerCase(this string input)
-            => string.IsNullOrEmpty(input) ? input : $"{char.ToLowerInvariant(input[0])}{input[1..]}";
+            => string.IsNullOrEmpty(input) ? input : $"{char.ToLowerInvariant(input[0])}{input.Substring(1)}";
     }
 }

--- a/src/serialization/ParseNodeFactoryRegistry.cs
+++ b/src/serialization/ParseNodeFactoryRegistry.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Kiota.Abstractions.Serialization
                 throw new ArgumentNullException(nameof(contentType));
             _ = content ?? throw new ArgumentNullException(nameof(content));
 
-            var vendorSpecificContentType = contentType.Split(";", StringSplitOptions.RemoveEmptyEntries).First();
+            var vendorSpecificContentType = contentType.Split(";".ToCharArray(), StringSplitOptions.RemoveEmptyEntries).First();
             if(ContentTypeAssociatedFactories.ContainsKey(vendorSpecificContentType))
                 return ContentTypeAssociatedFactories[vendorSpecificContentType].GetRootParseNode(vendorSpecificContentType, content);
 

--- a/src/serialization/SerializationWriterFactoryRegistry.cs
+++ b/src/serialization/SerializationWriterFactoryRegistry.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Kiota.Abstractions.Serialization
             if(string.IsNullOrEmpty(contentType))
                 throw new ArgumentNullException(nameof(contentType));
 
-            var vendorSpecificContentType = contentType.Split(";", StringSplitOptions.RemoveEmptyEntries).First();
+            var vendorSpecificContentType = contentType.Split(";".ToCharArray(), StringSplitOptions.RemoveEmptyEntries).First();
             if(ContentTypeAssociatedFactories.ContainsKey(vendorSpecificContentType))
                 return ContentTypeAssociatedFactories[vendorSpecificContentType].GetSerializationWriter(vendorSpecificContentType);
             

--- a/src/store/InMemoryBackingStore.cs
+++ b/src/store/InMemoryBackingStore.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Kiota.Abstractions.Extensions;
 
 namespace Microsoft.Kiota.Abstractions.Store
 {


### PR DESCRIPTION
This is part of #12 

Changes include: -

- implement own version of TryAdd for dictionary
- change overload of string.split
- dropped use of range/index operators not available