### PR TITLE
Fix for backing store registration in .net framework

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -75,7 +75,7 @@ stages:
         inputs:
           command: test
           projects: '$(Build.SourcesDirectory)\Microsoft.Kiota.Abstractions.sln'
-          arguments: '--configuration $(BuildConfiguration) --no-build'
+          arguments: '--configuration $(BuildConfiguration) --no-build --framework net6.0'
 
       # CredScan
       - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.0.0-preview.9] - 2022-06-13
+
+### Changed
+
+- Fixes a bug where the backing store would fail to be set in clients running .Net framework.
+
 ## [1.0.0-preview.8] - 2022-05-11
 
 ### Added

--- a/Microsoft.Kiota.Abstractions.Tests/ApiClientBuilderTests.cs
+++ b/Microsoft.Kiota.Abstractions.Tests/ApiClientBuilderTests.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.Kiota.Abstractions.Serialization;
+using Microsoft.Kiota.Abstractions.Store;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Kiota.Abstractions.Tests
+{
+    public class ApiClientBuilderTests
+    {
+        private const string StreamContentType = "application/octet-stream";
+    
+        [Fact]
+        public void EnableBackingStoreForSerializationWriterFactory()
+        {
+            // Arrange
+            var serializationFactoryRegistry = new SerializationWriterFactoryRegistry();
+            var mockSerializationWriterFactory = new Mock<ISerializationWriterFactory>();
+            serializationFactoryRegistry.ContentTypeAssociatedFactories.Add(StreamContentType, mockSerializationWriterFactory.Object);
+        
+            Assert.IsNotType<BackingStoreSerializationWriterProxyFactory>(serializationFactoryRegistry.ContentTypeAssociatedFactories[StreamContentType]);
+        
+            // Act
+            ApiClientBuilder.EnableBackingStoreForSerializationWriterFactory(serializationFactoryRegistry);
+        
+            // Assert the type has changed due to backing store enabling
+            Assert.IsType<BackingStoreSerializationWriterProxyFactory>(serializationFactoryRegistry.ContentTypeAssociatedFactories[StreamContentType]);
+        }
+    
+        [Fact]
+        public void EnableBackingStoreForParseNodeFactory()
+        {
+            // Arrange
+            var parseNodeRegistry = new ParseNodeFactoryRegistry();
+            var mockParseNodeFactory = new Mock<IParseNodeFactory>();
+            parseNodeRegistry.ContentTypeAssociatedFactories.Add(StreamContentType, mockParseNodeFactory.Object);
+        
+            Assert.IsNotType<BackingStoreParseNodeFactory>(parseNodeRegistry.ContentTypeAssociatedFactories[StreamContentType]);
+        
+            // Act
+            ApiClientBuilder.EnableBackingStoreForParseNodeFactory(parseNodeRegistry);
+        
+            // Assert the type has changed due to backing store enabling
+            Assert.IsType<BackingStoreParseNodeFactory>(parseNodeRegistry.ContentTypeAssociatedFactories[StreamContentType]);
+        }
+    }
+}

--- a/Microsoft.Kiota.Abstractions.Tests/Microsoft.Kiota.Abstractions.Tests.csproj
+++ b/Microsoft.Kiota.Abstractions.Tests/Microsoft.Kiota.Abstractions.Tests.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-
     <IsPackable>false</IsPackable>
+    <TargetFrameworks>net462;net6.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,6 +13,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <!-- We need Microsoft.TestPlatform.ObjectModel for net framework execution in linux environments https://github.com/microsoft/vstest/issues/2469-->
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/src/ApiClientBuilder.cs
+++ b/src/ApiClientBuilder.cs
@@ -72,7 +72,8 @@ namespace Microsoft.Kiota.Abstractions
             foreach(var entry in registry
                                     .ContentTypeAssociatedFactories
                                     .Where(x => !(x.Value is BackingStoreParseNodeFactory ||
-                                                    x.Value is ParseNodeFactoryRegistry)))
+                                                    x.Value is ParseNodeFactoryRegistry))
+                                    .ToList()) // earlier versions of .NET do not allow direct modification of dictionary values while iterating
             {
                 registry.ContentTypeAssociatedFactories[entry.Key] = new BackingStoreParseNodeFactory(entry.Value);
             }
@@ -82,7 +83,8 @@ namespace Microsoft.Kiota.Abstractions
             foreach(var entry in registry
                                     .ContentTypeAssociatedFactories
                                     .Where(x => !(x.Value is BackingStoreSerializationWriterProxyFactory ||
-                                                    x.Value is SerializationWriterFactoryRegistry)))
+                                                    x.Value is SerializationWriterFactoryRegistry))
+                                    .ToList()) // earlier versions of .NET do not allow direct modification of dictionary values while iterating
             {
                 registry.ContentTypeAssociatedFactories[entry.Key] = new BackingStoreSerializationWriterProxyFactory(entry.Value);
             }

--- a/src/Microsoft.Kiota.Abstractions.csproj
+++ b/src/Microsoft.Kiota.Abstractions.csproj
@@ -14,7 +14,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>preview.8</VersionSuffix>
+    <VersionSuffix>preview.9</VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <SignAssembly>false</SignAssembly>
     <DelaySign>false</DelaySign>
@@ -23,7 +23,7 @@
     <!-- Enable this line once we go live to prevent breaking changes -->
     <!-- <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> -->
     <PackageReleaseNotes>
-      - Breaking: added an additional parameter to authentication methods to carry contextual information.
+      - Fixes a bug where the backing store would fail to be set in clients running .Net framework.
     </PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/src/store/InMemoryBackingStore.cs
+++ b/src/store/InMemoryBackingStore.cs
@@ -128,8 +128,8 @@ namespace Microsoft.Kiota.Abstractions.Store
             set
             {
                 isInitializationComplete = value;
-                foreach(var entry in store)
-                    store[entry.Key] = new(!value, entry.Value.Item2);
+                foreach(var key in store.Keys)
+                    store[key] = new(!value, store[key].Item2);
             }
         }
     }


### PR DESCRIPTION
This PR closes https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/issues/470

It fixes an issue with clients running versions before .NET 5 where modifying dictionary values while iterating was not allowed.

Tests have been added to reflect this change and a `net462` target added to the project to capture such issues in future tests.

**Background info**
- https://github.com/dotnet/runtime/pull/34667 and https://github.com/dotnet/runtime/issues/34606