### PR TITLE
Default DateTime format in URL path/query to ISO 8601

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.0.0-preview.10] - 2022-08-11
+
+### Changed
+
+- DateTime instances added to the url paths to default to ISO 8601
+- Adds excplicit error message if the url template expects URI when accessing the URI from RequestInformation
+
 ## [1.0.0-preview.9] - 2022-06-13
 
 ### Changed

--- a/Microsoft.Kiota.Abstractions.Tests/RequestInformationTests.cs
+++ b/Microsoft.Kiota.Abstractions.Tests/RequestInformationTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Moq;
 using Xunit;
@@ -25,8 +26,6 @@ namespace Microsoft.Kiota.Abstractions.Tests
             Assert.Equal("foo",testRequest.QueryParameters.First().Key);
             Assert.Equal("bar", testRequest.QueryParameters.First().Value.ToString());
         }
-
-
         [Fact]
         public void AddsAndRemovesRequestOptions()
         {
@@ -68,6 +67,84 @@ namespace Microsoft.Kiota.Abstractions.Tests
             Assert.True(requestInfo.QueryParameters.ContainsKey("%24select"));
             Assert.False(requestInfo.QueryParameters.ContainsKey("select"));
             Assert.Equal("%24select",requestInfo.QueryParameters.First().Key);
+        }
+        [Fact]
+        public void SetsPathParametersOfDateTimeOffsetType()
+        {
+            // Arrange as the request builders would
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = Method.GET,
+                UrlTemplate = "http://localhost/getDirectRoutingCalls(fromDateTime='{fromDateTime}',toDateTime='{toDateTime}')"
+            };
+
+            // Act
+            var fromDateTime = new DateTimeOffset(2022, 8, 1, 0, 0, 0, TimeSpan.Zero);
+            var toDateTime = new DateTimeOffset(2022, 8, 2, 0, 0, 0, TimeSpan.Zero);
+            var pathParameters = new Dictionary<string, object>();
+            pathParameters.Add("fromDateTime", fromDateTime);
+            pathParameters.Add("toDateTime", toDateTime);
+
+            requestInfo.PathParameters = pathParameters;
+
+            // Assert
+            Assert.Contains("fromDateTime='2022-08-01T00%3A00%3A00.0000000%2B00%3A00'", requestInfo.URI.OriginalString);
+            Assert.Contains("toDateTime='2022-08-02T00%3A00%3A00.0000000%2B00%3A00'", requestInfo.URI.OriginalString);
+        }
+        [Fact]
+        public void SetsPathParametersOfBooleanType()
+        {
+            // Arrange as the request builders would
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = Method.GET,
+                UrlTemplate = "http://localhost/users{?%24count}"
+            };
+
+            // Act
+            var count = true;
+            var pathParameters = new Dictionary<string, object>();
+            pathParameters.Add("%24count", count);
+
+            requestInfo.PathParameters = pathParameters;
+
+            // Assert
+            Assert.Contains("%24count=true", requestInfo.URI.OriginalString);
+        }
+
+        [Fact]
+        public void ThrowsInvalidOperationExceptionWhenBaseUrlNotSet()
+        {
+            // Arrange as the request builders would
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = Method.GET,
+                UrlTemplate = "{+baseurl}/users{?%24count}"
+            };
+
+            // Assert
+            var exception = Assert.Throws<InvalidOperationException>(() => requestInfo.URI);
+            Assert.Contains("baseurl", exception.Message);
+        }
+
+        [Fact]
+        public void BuildsUrlOnProvidedBaseUrl()
+        {
+            // Arrange as the request builders would
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = Method.GET,
+                UrlTemplate = "{+baseurl}/users{?%24count}"
+            };
+
+            // Act
+            requestInfo.PathParameters = new Dictionary<string, object>() 
+            {
+                { "baseurl","http://localhost" }
+            };
+
+            // Assert
+            Assert.Contains("http://localhost", requestInfo.URI.OriginalString);
         }
     }
 

--- a/src/Microsoft.Kiota.Abstractions.csproj
+++ b/src/Microsoft.Kiota.Abstractions.csproj
@@ -14,7 +14,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>preview.9</VersionSuffix>
+    <VersionSuffix>preview.10</VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <SignAssembly>false</SignAssembly>
     <DelaySign>false</DelaySign>
@@ -23,7 +23,8 @@
     <!-- Enable this line once we go live to prevent breaking changes -->
     <!-- <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> -->
     <PackageReleaseNotes>
-      - Fixes a bug where the backing store would fail to be set in clients running .Net framework.
+        - DateTime instances added to the url paths to default to ISO 8601
+        - Adds excplicit error message if the url template expects URI when accessing the URI from RequestInformation
     </PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>


### PR DESCRIPTION
This PR closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1346 and closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1443

Changes include : - 
- Resolves `DateTimeOffset` and `DateTime` objects to be placed in URL segments or query parameters to default to the ISO 8601
- Add explicit error message in the event that URI property is accessed without setting the "baseurl" path parameter (if needed)
- Adds tests to capture and validate these scenarios