### PR TITLE
InMemoryBackingstore fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-## [1.0.0-preview12] - 2022-09-19
+## [1.0.0-preview.13] - 2022-10-05
+
+### Changed
+
+- Fixes a bug in the InMemoryBackingstore that would not detect changes in nested complex types and collections
+
+## [1.0.0-preview.12] - 2022-09-19
 
 ### Added
 
 - Added tracing support for request information content type.
 
-## [1.0.0-preview11] - 2022-09-06
+## [1.0.0-preview.11] - 2022-09-06
 
 ### Added
 

--- a/Microsoft.Kiota.Abstractions.Tests/Mocks/TestEntity.cs
+++ b/Microsoft.Kiota.Abstractions.Tests/Mocks/TestEntity.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Kiota.Abstractions.Serialization;
+using Microsoft.Kiota.Abstractions.Store;
+
+namespace Microsoft.Kiota.Abstractions.Tests.Mocks
+{
+    public class TestEntity : IParsable, IAdditionalDataHolder, IBackedModel
+    {
+        /// <summary>Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.</summary>
+        public IDictionary<string, object> AdditionalData
+        {
+            get { return BackingStore?.Get<IDictionary<string, object>>("additionalData"); }
+            set { BackingStore?.Set("additionalData", value); }
+        }
+        /// <summary>Stores model information.</summary>
+        public IBackingStore BackingStore { get; private set; }
+        /// <summary>The id property</summary>
+        public string Id
+        {
+            get { return BackingStore?.Get<string>("id"); }
+            set { BackingStore?.Set("id", value); }
+        }
+        /// <summary>The OdataType property</summary>
+        public string OdataType
+        {
+            get { return BackingStore?.Get<string>("@odata.type"); }
+            set { BackingStore?.Set("@odata.type", value); }
+        }
+        /// <summary>The telephone numbers for the user. NOTE: Although this is a string collection, only one number can be set for this property. Read-only for users synced from on-premises directory. Returned by default. Supports $filter (eq, not, ge, le, startsWith).</summary>
+        public List<string> BusinessPhones
+        {
+            get { return BackingStore?.Get<List<string>>("businessPhones"); }
+            set { BackingStore?.Set("businessPhones", value); }
+        }
+        /// <summary>The user or contact that is this user&apos;s manager. Read-only. (HTTP Methods: GET, PUT, DELETE.). Supports $expand.</summary>
+        public TestEntity Manager
+        {
+            get { return BackingStore?.Get<TestEntity>("manager"); }
+            set { BackingStore?.Set("manager", value); }
+        }
+        /// <summary>
+        /// Instantiates a new entity and sets the default values.
+        /// </summary>
+        public TestEntity()
+        {
+            BackingStore = BackingStoreFactorySingleton.Instance.CreateBackingStore();
+            AdditionalData = new Dictionary<string, object>();
+            OdataType = "#microsoft.graph.testEntity";
+        }
+        /// <summary>
+        /// The deserialization information for the current model
+        /// </summary>
+        public IDictionary<string, Action<IParseNode>> GetFieldDeserializers()
+        {
+            return new Dictionary<string, Action<IParseNode>> {
+                {"businessPhones", n => { BusinessPhones = n.GetCollectionOfPrimitiveValues<string>()?.ToList(); } },
+                {"id", n => { Id = n.GetStringValue(); } },
+                {"manager", n => { Manager = n.GetObjectValue<TestEntity>(TestEntity.CreateFromDiscriminatorValue); } },
+                {"@odata.type", n => { OdataType = n.GetStringValue(); } },
+            };
+        }
+        /// <summary>
+        /// Serializes information the current object
+        /// <param name="writer">Serialization writer to use to serialize this model</param>
+        /// </summary>
+        public void Serialize(ISerializationWriter writer)
+        {
+            _ = writer ?? throw new ArgumentNullException(nameof(writer));
+            writer.WriteCollectionOfPrimitiveValues<string>("businessPhones", BusinessPhones);
+            writer.WriteStringValue("id", Id);
+            writer.WriteObjectValue<TestEntity>("manager", Manager);
+            writer.WriteStringValue("@odata.type", OdataType);
+            writer.WriteAdditionalData(AdditionalData);
+        }
+        public static TestEntity CreateFromDiscriminatorValue(IParseNode parseNode)
+        {
+            return new TestEntity();
+        }
+    }
+}

--- a/Microsoft.Kiota.Abstractions.Tests/Store/InMemoryBackingStoreTests.cs
+++ b/Microsoft.Kiota.Abstractions.Tests/Store/InMemoryBackingStoreTests.cs
@@ -1,5 +1,7 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Kiota.Abstractions.Store;
+using Microsoft.Kiota.Abstractions.Tests.Mocks;
 using Xunit;
 
 namespace Microsoft.Kiota.Abstractions.Tests.Store
@@ -49,6 +51,175 @@ namespace Microsoft.Kiota.Abstractions.Tests.Store
             Assert.Single(testBackingStore.EnumerateKeysForValuesChangedToNull());
             Assert.Equal(3, testBackingStore.Enumerate().Count());// all values come back
             Assert.Equal("phone", testBackingStore.EnumerateKeysForValuesChangedToNull().First());
+        }
+
+        [Fact]
+        public void TestsBackingStoreEmbeddedInModel()
+        {
+            // Arrange dummy user with initialized backingstore
+            var testUser = new TestEntity
+            {
+                Id = "84c747c1-d2c0-410d-ba50-fc23e0b4abbe",
+            };
+            testUser.BackingStore.InitializationCompleted = true;
+            // Act on the data by making a change
+            testUser.BusinessPhones = new List<string> 
+            {
+                "+1 234 567 891"
+            };
+            // Assert by retrieving only changed values
+            testUser.BackingStore.ReturnOnlyChangedValues = true;
+            var changedValues = testUser.BackingStore.Enumerate();
+            Assert.NotEmpty(changedValues);
+            Assert.Single(changedValues);
+            Assert.Equal("businessPhones", changedValues.First().Key);
+        }
+        [Fact]
+        public void TestsBackingStoreEmbeddedInModelWithAdditionDataValues()
+        {
+            // Arrange dummy user with initialized backingstore
+            var testUser = new TestEntity
+            {
+                Id = "84c747c1-d2c0-410d-ba50-fc23e0b4abbe",
+                AdditionalData = new Dictionary<string, object> 
+                {
+                    { "extensionData" , null }
+                }
+            };
+            testUser.BackingStore.InitializationCompleted = true;
+            // Act on the data by making a change to a property and additionalData
+            testUser.BusinessPhones = new List<string>
+            {
+                "+1 234 567 891"
+            };
+            testUser.AdditionalData.Add("anotherExtension", null);
+            // Assert by retrieving only changed values
+            testUser.BackingStore.ReturnOnlyChangedValues = true;
+            var changedValues = testUser.BackingStore.Enumerate();
+            Assert.NotEmpty(changedValues);
+            Assert.Equal(2, changedValues.Count());
+            var resultList = changedValues.ToList();
+            Assert.Equal("additionalData", resultList[0].Key);
+            Assert.Equal("businessPhones", resultList[1].Key);
+        }
+        [Fact]
+        public void TestsBackingStoreEmbeddedInModelWithCollectionPropertyReplacedWithNewCollection()
+        {
+            // Arrange dummy user with initialized backingstore
+            var testUser = new TestEntity
+            {
+                Id = "84c747c1-d2c0-410d-ba50-fc23e0b4abbe",
+                BusinessPhones = new List<string>
+                {
+                    "+1 234 567 891"
+                }
+            };
+            testUser.BackingStore.InitializationCompleted = true;
+            // Act on the data by making a change
+            testUser.BusinessPhones = new List<string>
+            {
+                "+1 234 567 891"
+            };
+            // Assert by retrieving only changed values
+            testUser.BackingStore.ReturnOnlyChangedValues = true;
+            var changedValues = testUser.BackingStore.Enumerate();
+            Assert.NotEmpty(changedValues);
+            Assert.Single(changedValues);
+            Assert.Equal("businessPhones", changedValues.First().Key);
+        }
+        [Fact]
+        public void TestsBackingStoreEmbeddedInModelWithCollectionPropertyReplacedWithNull()
+        {
+            // Arrange dummy user with initialized backingstore
+            var testUser = new TestEntity
+            {
+                Id = "84c747c1-d2c0-410d-ba50-fc23e0b4abbe",
+                BusinessPhones = new List<string>
+                {
+                    "+1 234 567 891"
+                }
+            };
+            testUser.BackingStore.InitializationCompleted = true;
+            // Act on the data by making a change
+            testUser.BusinessPhones = null;
+            // Assert by retrieving only changed values
+            testUser.BackingStore.ReturnOnlyChangedValues = true;
+            var changedValues = testUser.BackingStore.Enumerate();
+            Assert.NotEmpty(changedValues);
+            Assert.Single(changedValues);
+            Assert.Equal("businessPhones", changedValues.First().Key);
+            var changedValuesToNull = testUser.BackingStore.EnumerateKeysForValuesChangedToNull();
+            Assert.NotEmpty(changedValuesToNull);
+            Assert.Single(changedValuesToNull);
+            Assert.Equal("businessPhones", changedValues.First().Key);
+        }
+        [Fact]
+        public void TestsBackingStoreEmbeddedInModelWithCollectionPropertyModifiedByAdd()
+        {
+            // Arrange dummy user with initialized backingstore
+            var testUser = new TestEntity
+            {
+                Id = "84c747c1-d2c0-410d-ba50-fc23e0b4abbe",
+                BusinessPhones = new List<string>
+                {
+                    "+1 234 567 891"
+                }
+            };
+            testUser.BackingStore.InitializationCompleted = true;
+            // Act on the data by making a change
+            testUser.BusinessPhones.Add("+1 234 567 891");
+            // Assert by retrieving only changed values
+            testUser.BackingStore.ReturnOnlyChangedValues = true;
+            var changedValues = testUser.BackingStore.Enumerate();
+            Assert.NotEmpty(changedValues);
+            Assert.Single(changedValues);
+            Assert.Equal("businessPhones", changedValues.First().Key);
+        }
+        [Fact]
+        public void TestsBackingStoreEmbeddedInModelWithBySettingNestedIBackedModel()
+        {
+            // Arrange dummy user with initialized backingstore
+            var testUser = new TestEntity
+            {
+                Id = "84c747c1-d2c0-410d-ba50-fc23e0b4abbe"
+            };
+            testUser.BackingStore.InitializationCompleted = true;
+            // Act on the data by making a change
+            testUser.Manager = new TestEntity 
+            {
+                Id = "2fe22fe5-1132-42cf-90f9-1dc17e325a74"
+            };
+            // Assert by retrieving only changed values
+            testUser.BackingStore.ReturnOnlyChangedValues = true;
+            var changedValues = testUser.BackingStore.Enumerate();
+            Assert.NotEmpty(changedValues);
+            Assert.Single(changedValues);
+            Assert.Equal("manager", changedValues.First().Key);
+        }
+        [Fact]
+        public void TestsBackingStoreEmbeddedInModelWithByUpdatingNestedIBackedModel()
+        {
+            // Arrange dummy user with initialized backingstore
+            var testUser = new TestEntity
+            {
+                Id = "84c747c1-d2c0-410d-ba50-fc23e0b4abbe",
+                Manager = new TestEntity
+                {
+                    Id = "2fe22fe5-1132-42cf-90f9-1dc17e325a74"
+                }
+            };
+            testUser.BackingStore.InitializationCompleted = testUser.Manager.BackingStore.InitializationCompleted = true;
+            // Act on the data by making a change in the nested Ibackedmodel
+            testUser.Manager.BusinessPhones = new List<string>
+            {
+                "+1 234 567 891"
+            };
+            // Assert by retrieving only changed values
+            testUser.BackingStore.ReturnOnlyChangedValues = true;
+            var changedValues = testUser.BackingStore.Enumerate();
+            Assert.NotEmpty(changedValues);
+            Assert.Single(changedValues);
+            Assert.Equal("manager", changedValues.First().Key);//Backingstore should detect manager property changed
         }
     }
 }

--- a/src/Microsoft.Kiota.Abstractions.csproj
+++ b/src/Microsoft.Kiota.Abstractions.csproj
@@ -14,7 +14,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>preview.12</VersionSuffix>
+    <VersionSuffix>preview.13</VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <SignAssembly>false</SignAssembly>
     <DelaySign>false</DelaySign>
@@ -23,7 +23,7 @@
     <!-- Enable this line once we go live to prevent breaking changes -->
     <!-- <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> -->
     <PackageReleaseNotes>
-      - Added tracing support for request information content type.
+      - Fixes a bug in the InMemoryBackingstore that would not detect changes in nested complex types and collections
     </PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>


### PR DESCRIPTION
This PR closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1448

It fixes a bug in the InMemoryBackingstore as it would fail to return changed properties if
- A property is a collection that was modified that was modified. This is resolved by annotation of the property with the size which is checked/synced when the property getter is called. 
- A property is a complex object(IBackedModel) that had one of its properties modified. This is now resolved by subscribing to the nested models events and using its changes to flag the property change.