### PR TITLE
Changes the responseHandler to be a requestOption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.0.0-preview.14] - 2022-10-17
+
+### Changed
+
+- Changes the ResponeHandler parameter in IRequestAdapter to be a RequestOption
+
 ## [1.0.0-preview.13] - 2022-10-05
 
 ### Changed

--- a/Microsoft.Kiota.Abstractions.Tests/RequestInformationTests.cs
+++ b/Microsoft.Kiota.Abstractions.Tests/RequestInformationTests.cs
@@ -169,6 +169,31 @@ namespace Microsoft.Kiota.Abstractions.Tests
             // Assert we can build urls based on a Proxy based base url
             Assert.Equal("https://proxy.apisandbox.msdn.microsoft.com/svc?url=https://graph.microsoft.com/beta/users?%24count=true", requestInfo.URI.OriginalString);
         }
+
+        [Fact]
+        public void GetsAndSetsResponseHandlerByType()
+        {
+            // Arrange as the request builders would
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = Method.GET,
+                UrlTemplate = "{+baseurl}/users{?%24count}"
+            };
+
+            // Assert we have NO option
+            Assert.Null(requestInfo.GetRequestOption<ResponseHandlerOption>());
+
+            // Act
+            requestInfo.PathParameters = new Dictionary<string, object>()
+            {
+                { "baseurl", "http://localhost" },
+                { "%24count", true }
+            };
+            requestInfo.SetResponseHandler(new NativeResponseHandler());
+
+            // Assert we now have an option
+            Assert.NotNull(requestInfo.GetRequestOption<ResponseHandlerOption>());
+        }
     }
 
     /// <summary>The messages in a mailbox or folder. Read-only. Nullable.</summary>

--- a/src/IRequestAdapter.cs
+++ b/src/IRequestAdapter.cs
@@ -2,7 +2,6 @@
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -30,48 +29,43 @@ namespace Microsoft.Kiota.Abstractions
         /// </summary>
         /// <param name="requestInfo">The RequestInformation object to use for the HTTP request.</param>
         /// <param name="factory">The factory of the response model to deserialize the response into.</param>
-        /// <param name="responseHandler">The response handler to use for the HTTP request instead of the default handler.</param>
         /// <param name="errorMapping">The error factories mapping to use in case of a failed request.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use for cancelling the requests.</param>
         /// <returns>The deserialized response model.</returns>
-        Task<ModelType> SendAsync<ModelType>(RequestInformation requestInfo, ParsableFactory<ModelType> factory, IResponseHandler responseHandler = default, Dictionary<string, ParsableFactory<IParsable>> errorMapping = default, CancellationToken cancellationToken = default) where ModelType : IParsable;
+        Task<ModelType> SendAsync<ModelType>(RequestInformation requestInfo, ParsableFactory<ModelType> factory, Dictionary<string, ParsableFactory<IParsable>> errorMapping = default, CancellationToken cancellationToken = default) where ModelType : IParsable;
         /// <summary>
         /// Executes the HTTP request specified by the given RequestInformation and returns the deserialized response model collection.
         /// </summary>
         /// <param name="requestInfo">The RequestInformation object to use for the HTTP request.</param>
         /// <param name="factory">The factory of the response model to deserialize the response into.</param>
-        /// <param name="responseHandler">The response handler to use for the HTTP request instead of the default handler.</param>
         /// <param name="errorMapping">The error factories mapping to use in case of a failed request.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use for cancelling the requests.</param>
         /// <returns>The deserialized response model collection.</returns>
-        Task<IEnumerable<ModelType>> SendCollectionAsync<ModelType>(RequestInformation requestInfo, ParsableFactory<ModelType> factory, IResponseHandler responseHandler = default, Dictionary<string, ParsableFactory<IParsable>> errorMapping = default, CancellationToken cancellationToken = default) where ModelType : IParsable;
+        Task<IEnumerable<ModelType>> SendCollectionAsync<ModelType>(RequestInformation requestInfo, ParsableFactory<ModelType> factory, Dictionary<string, ParsableFactory<IParsable>> errorMapping = default, CancellationToken cancellationToken = default) where ModelType : IParsable;
         /// <summary>
         /// Executes the HTTP request specified by the given RequestInformation and returns the deserialized primitive response model.
         /// </summary>
         /// <param name="requestInfo">The RequestInformation object to use for the HTTP request.</param>
-        /// <param name="responseHandler">The response handler to use for the HTTP request instead of the default handler.</param>
         /// <param name="errorMapping">The error factories mapping to use in case of a failed request.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use for cancelling the requests.</param>
         /// <returns>The deserialized primitive response model.</returns>
-        Task<ModelType> SendPrimitiveAsync<ModelType>(RequestInformation requestInfo, IResponseHandler responseHandler = default, Dictionary<string, ParsableFactory<IParsable>> errorMapping = default, CancellationToken cancellationToken = default);
+        Task<ModelType> SendPrimitiveAsync<ModelType>(RequestInformation requestInfo, Dictionary<string, ParsableFactory<IParsable>> errorMapping = default, CancellationToken cancellationToken = default);
         /// <summary>
         /// Executes the HTTP request specified by the given RequestInformation and returns the deserialized primitive response model collection.
         /// </summary>
         /// <param name="requestInfo">The RequestInformation object to use for the HTTP request.</param>
-        /// <param name="responseHandler">The response handler to use for the HTTP request instead of the default handler.</param>
         /// <param name="errorMapping">The error factories mapping to use in case of a failed request.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use for cancelling the requests.</param>
         /// <returns>The deserialized primitive response model collection.</returns>
-        Task<IEnumerable<ModelType>> SendPrimitiveCollectionAsync<ModelType>(RequestInformation requestInfo, IResponseHandler responseHandler = default, Dictionary<string, ParsableFactory<IParsable>> errorMapping = default, CancellationToken cancellationToken = default);
+        Task<IEnumerable<ModelType>> SendPrimitiveCollectionAsync<ModelType>(RequestInformation requestInfo, Dictionary<string, ParsableFactory<IParsable>> errorMapping = default, CancellationToken cancellationToken = default);
         /// <summary>
         /// Executes the HTTP request specified by the given RequestInformation with no return content.
         /// </summary>
         /// <param name="requestInfo">The RequestInformation object to use for the HTTP request.</param>
-        /// <param name="responseHandler">The response handler to use for the HTTP request instead of the default handler.</param>
         /// <param name="errorMapping">The error factories mapping to use in case of a failed request.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use for cancelling the requests.</param>
         /// <returns>A Task to await completion.</returns>
-        Task SendNoContentAsync(RequestInformation requestInfo, IResponseHandler responseHandler = default, Dictionary<string, ParsableFactory<IParsable>> errorMapping = default, CancellationToken cancellationToken = default);
+        Task SendNoContentAsync(RequestInformation requestInfo, Dictionary<string, ParsableFactory<IParsable>> errorMapping = default, CancellationToken cancellationToken = default);
         /// <summary>
         /// The base url for every request.
         /// </summary>

--- a/src/Microsoft.Kiota.Abstractions.csproj
+++ b/src/Microsoft.Kiota.Abstractions.csproj
@@ -14,7 +14,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>preview.13</VersionSuffix>
+    <VersionSuffix>preview.14</VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <SignAssembly>false</SignAssembly>
     <DelaySign>false</DelaySign>
@@ -23,7 +23,7 @@
     <!-- Enable this line once we go live to prevent breaking changes -->
     <!-- <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> -->
     <PackageReleaseNotes>
-      - Fixes a bug in the InMemoryBackingstore that would not detect changes in nested complex types and collections
+      - Changes the ResponeHandler parameter in IRequestAdapter to be a RequestOption
     </PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/src/RequestInformation.cs
+++ b/src/RequestInformation.cs
@@ -153,6 +153,27 @@ namespace Microsoft.Kiota.Abstractions
             foreach(var optionName in options.Where(x => x != null).Select(x => x.GetType().FullName))
                 _requestOptions.Remove(optionName);
         }
+
+        /// <summary>
+        /// Gets a <see cref="IRequestOption"/> instance of the matching type.
+        /// </summary>
+        public T GetRequestOption<T>() => _requestOptions.TryGetValue(typeof(T).FullName, out var requestOption) ? (T)requestOption : default;
+
+        /// <summary>
+        /// Adds a <see cref="IResponseHandler"/> as a <see cref="IRequestOption"/> for the request.
+        /// </summary>
+        public void SetResponseHandler(IResponseHandler responseHandler)
+        {
+            if(responseHandler == null)
+                throw new ArgumentNullException(nameof(responseHandler));
+
+            var responseHandlerOption = new ResponseHandlerOption
+            {
+                ResponseHandler = responseHandler
+            };
+            AddRequestOptions(new[] { responseHandlerOption });
+        }
+
         private const string BinaryContentType = "application/octet-stream";
         private const string ContentTypeHeader = "Content-Type";
         /// <summary>

--- a/src/ResponseHandlerOption.cs
+++ b/src/ResponseHandlerOption.cs
@@ -1,0 +1,17 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Kiota.Abstractions
+{
+    /// <summary>
+    ///     Defines the <see cref="IRequestOption"/> for holding a <see cref="IResponseHandler"/>
+    /// </summary>
+    public class ResponseHandlerOption : IRequestOption
+    {
+        /// <summary>
+        /// The <see cref="IResponseHandler"/> to use for a request
+        /// </summary>
+        public IResponseHandler ResponseHandler { get; set; }
+    }
+}


### PR DESCRIPTION
This PR is part of https://github.com/microsoft/kiota/issues/1858

Changes include : -
- Updates `Send*` methods in `IRequestAdapter` to move the `responseHanlderParameter`
- Adds the `SetResponseHandler` method to be able to directly add `IResposeHandler` to a request
- Adds the `GetRequestOption<T>` method to be able to get an `IRequestOption` instance by the type in O(1) time.
- Adds tests to validate