### PR TITLE
Handle cases of collection of IBackedModels in the InMemoryBackingStore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ bld/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 
+.idea
+
 # Visual Studio 2017 auto generated files
 Generated\ Files/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.0.0-preview.17] - 2022-11-11
+
+### Changed
+
+- Fixes a bug in the InMemoryBackingstore that would not detect changes in nested collections of complex types that had backing stores
+
 ## [1.0.0-preview.16] - 2022-10-28
 
 ### Changed

--- a/Microsoft.Kiota.Abstractions.Tests/Mocks/TestEntity.cs
+++ b/Microsoft.Kiota.Abstractions.Tests/Mocks/TestEntity.cs
@@ -40,6 +40,12 @@ namespace Microsoft.Kiota.Abstractions.Tests.Mocks
             get { return BackingStore?.Get<TestEntity>("manager"); }
             set { BackingStore?.Set("manager", value); }
         }
+        /// <summary>The user or contact that is this user& works with.</summary>
+        public List<TestEntity> Colleagues
+        {
+            get { return BackingStore?.Get<List<TestEntity>>("colleagues"); }
+            set { BackingStore?.Set("colleagues", value); }
+        }
         /// <summary>
         /// Instantiates a new entity and sets the default values.
         /// </summary>

--- a/Microsoft.Kiota.Abstractions.Tests/Store/InMemoryBackingStoreTests.cs
+++ b/Microsoft.Kiota.Abstractions.Tests/Store/InMemoryBackingStoreTests.cs
@@ -221,5 +221,33 @@ namespace Microsoft.Kiota.Abstractions.Tests.Store
             Assert.Single(changedValues);
             Assert.Equal("manager", changedValues.First().Key);//Backingstore should detect manager property changed
         }
+        [Fact]
+        public void TestsBackingStoreEmbeddedInModelWithByUpdatingNestedIBackedModelCollectionProperty()
+        {
+            // Arrange dummy user with initialized backingstore
+            var testUser = new TestEntity
+            {
+                Id = "84c747c1-d2c0-410d-ba50-fc23e0b4abbe",
+                Colleagues = new List<TestEntity> 
+                {
+                    new TestEntity
+                    {
+                        Id = "2fe22fe5-1132-42cf-90f9-1dc17e325a74"
+                    }
+                } 
+            };
+            testUser.BackingStore.InitializationCompleted = testUser.Colleagues[0].BackingStore.InitializationCompleted = true;
+            // Act on the data by making a change in the nested Ibackedmodel collection item
+            testUser.Colleagues[0].BusinessPhones = new List<string>
+            {
+                "+1 234 567 891"
+            };
+            // Assert by retrieving only changed values
+            testUser.BackingStore.ReturnOnlyChangedValues = true;
+            var changedValues = testUser.BackingStore.Enumerate();
+            Assert.NotEmpty(changedValues);
+            Assert.Single(changedValues);
+            Assert.Equal("colleagues", changedValues.First().Key);//Backingstore should detect manager property changed
+        }
     }
 }

--- a/src/Microsoft.Kiota.Abstractions.csproj
+++ b/src/Microsoft.Kiota.Abstractions.csproj
@@ -14,7 +14,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>preview.16</VersionSuffix>
+    <VersionSuffix>preview.17</VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <SignAssembly>false</SignAssembly>
     <DelaySign>false</DelaySign>
@@ -23,7 +23,7 @@
     <!-- Enable this line once we go live to prevent breaking changes -->
     <!-- <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> -->
     <PackageReleaseNotes>
-      - Fixed a bug where request bodies that are collections of single items would not serialize properly
+        - Fixes a bug in the InMemoryBackingstore that would not detect changes in nested collections of complex types that had backing stores
     </PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/src/store/InMemoryBackingStore.cs
+++ b/src/store/InMemoryBackingStore.cs
@@ -72,6 +72,10 @@ namespace Microsoft.Kiota.Abstractions.Store
             {// if its the first time adding a IBackedModel property to the store, subscribe to its BackingStore and use the events to flag the property is "dirty"
                 backedModel.BackingStore?.Subscribe((keyString, oldObject, newObject) => Set(key, value));
             }
+            else if(value is ICollection collectionValues)
+            {// if its the first time adding a IBackedModel collection property to the store, subscribe to item properties' BackingStores and use the events to flag the collection property is "dirty"
+                collectionValues.OfType<IBackedModel>().ToList().ForEach(model => model.BackingStore?.Subscribe((keyString, oldObject, newObject) => Set(key, value))); ;
+            }
 
             foreach(var sub in subscriptions.Values)
                 sub.Invoke(key, oldValue?.Item2, value);


### PR DESCRIPTION
This PR involves feedback from @Ndiritu on handling cases for nested collections of type IBackedModel in the Backingstore and is related to https://github.com/microsoft/kiota-abstractions-php/pull/13

In summary changes include.
- Updating the backing store to subscribe to the nested collection's backingstores so that updating the properties are also dirty tracked by the root backingstore.
- Updating tests to capture the scenario