### PR TITLE
Fixes empty query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.0.0-rc.2] - 2023-01-05
+
+### Changed
+
+- Release candidate 2
+- Prevents sending requests with empty query parameter values
+
 ## [1.0.0-rc.1] - 2022-12-15
 
 ### Changed

--- a/Microsoft.Kiota.Abstractions.Tests/RequestInformationTests.cs
+++ b/Microsoft.Kiota.Abstractions.Tests/RequestInformationTests.cs
@@ -71,6 +71,46 @@ namespace Microsoft.Kiota.Abstractions.Tests
             Assert.Equal("%24select",requestInfo.QueryParameters.First().Key);
         }
         [Fact]
+        public void DoesNotSetEmptyStringQueryParameters()
+        {
+            // Arrange as the request builders would
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = Method.GET,
+                UrlTemplate = "http://localhost/me{?%24search}"
+            };
+            Action<GetQueryParameters> q = x => x.Search = "";//empty string
+            var qParams = new GetQueryParameters();
+            q.Invoke(qParams);
+
+            // Act 
+            requestInfo.AddQueryParameters(qParams);
+
+            // Assert
+            Assert.False(requestInfo.QueryParameters.ContainsKey($"%24search"));
+            Assert.False(requestInfo.QueryParameters.ContainsKey("search"));
+        }
+        [Fact]
+        public void DoesNotSetEmptyCollectionQueryParameters()
+        {
+            // Arrange as the request builders would
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = Method.GET,
+                UrlTemplate = "http://localhost/me{?%24select}"
+            };
+            Action<GetQueryParameters> q = x => x.Select = Array.Empty<string>(); //empty array
+            var qParams = new GetQueryParameters();
+            q.Invoke(qParams);
+
+            // Act 
+            requestInfo.AddQueryParameters(qParams);
+
+            // Assert
+            Assert.False(requestInfo.QueryParameters.ContainsKey($"%24select"));
+            Assert.False(requestInfo.QueryParameters.ContainsKey("select"));
+        }
+        [Fact]
         public void SetsPathParametersOfDateTimeOffsetType()
         {
             // Arrange as the request builders would

--- a/src/Microsoft.Kiota.Abstractions.csproj
+++ b/src/Microsoft.Kiota.Abstractions.csproj
@@ -14,7 +14,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>rc.1</VersionSuffix>
+    <VersionSuffix>rc.2</VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <SignAssembly>false</SignAssembly>
     <DelaySign>false</DelaySign>
@@ -23,7 +23,8 @@
     <!-- Enable this line once we go live to prevent breaking changes -->
     <!-- <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> -->
     <PackageReleaseNotes>
-        - Release candidate 1.
+        - Release candidate 2.
+        - Prevents sending requests with empty query parameter values
     </PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/src/RequestInformation.cs
+++ b/src/RequestInformation.cs
@@ -110,10 +110,9 @@ namespace Microsoft.Kiota.Abstractions
                                         )
                                         .Where(x =>  x.Value != null &&
                                                     !QueryParameters.ContainsKey(x.Name) &&
-                                                    !string.IsNullOrEmpty(x.Value.ToString())))// no need to add an empty string value
+                                                    !string.IsNullOrEmpty(x.Value.ToString()) && // no need to add an empty string value
+                                                    (x.Value is not ICollection collection || collection.Count > 0))) // no need to add empty collection
             {
-                if(property.Value is ICollection collection && collection.Count == 0)
-                    continue; // no need to add an empty collection
                 QueryParameters.AddOrReplace(property.Name, property.Value);
             }
         }

--- a/src/RequestInformation.cs
+++ b/src/RequestInformation.cs
@@ -51,9 +51,11 @@ namespace Microsoft.Kiota.Abstractions
                     }
 
                     foreach(var queryStringParameter in QueryParameters)
-                    if(queryStringParameter.Value != null)
                     {
-                        parsedUrlTemplate.SetParameter(queryStringParameter.Key, GetSanitizedValue(queryStringParameter.Value));
+                        if(queryStringParameter.Value != null)
+                        {
+                            parsedUrlTemplate.SetParameter(queryStringParameter.Key, GetSanitizedValue(queryStringParameter.Value));
+                        }
                     }
                     return new Uri(parsedUrlTemplate.Resolve());
                 }

--- a/src/RequestInformation.cs
+++ b/src/RequestInformation.cs
@@ -3,6 +3,7 @@
 // ------------------------------------------------------------------------------
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -50,10 +51,10 @@ namespace Microsoft.Kiota.Abstractions
                     }
 
                     foreach(var queryStringParameter in QueryParameters)
-                        if(queryStringParameter.Value != null)
-                        {
-                            parsedUrlTemplate.SetParameter(queryStringParameter.Key, GetSanitizedValue(queryStringParameter.Value));
-                        }
+                    if(queryStringParameter.Value != null)
+                    {
+                        parsedUrlTemplate.SetParameter(queryStringParameter.Key, GetSanitizedValue(queryStringParameter.Value));
+                    }
                     return new Uri(parsedUrlTemplate.Resolve());
                 }
             }
@@ -105,8 +106,12 @@ namespace Microsoft.Kiota.Abstractions
                                                 Value: x.GetValue(source)
                                             )
                                         )
-                                        .Where(x => x.Value != null && !QueryParameters.ContainsKey(x.Name)))
+                                        .Where(x =>  x.Value != null &&
+                                                    !QueryParameters.ContainsKey(x.Name) &&
+                                                    !string.IsNullOrEmpty(x.Value.ToString())))// no need to add an empty string value
             {
+                if(property.Value is ICollection collection && collection.Count == 0)
+                    continue; // no need to add an empty collection
                 QueryParameters.AddOrReplace(property.Name, property.Value);
             }
         }


### PR DESCRIPTION
This PR closes #60

Changes include : - 

- Add checks to the  `AddQueryParameters` method to avoid adding empty collections and string to the `QueryParameters` when using request builders. 