### PR TITLE
Adds support for nullable ref types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.0.0-rc.4] - 2023-01-17
+
+### Changed
+
+- Adds support for nullable reference types 
+
 ## [1.0.0-rc.3] - 2023-01-09
 
 ### Changed

--- a/Microsoft.Kiota.Abstractions.Tests/Microsoft.Kiota.Abstractions.Tests.csproj
+++ b/Microsoft.Kiota.Abstractions.Tests/Microsoft.Kiota.Abstractions.Tests.csproj
@@ -5,6 +5,7 @@
     <TargetFrameworks>net462;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <OutputType>Library</OutputType>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Microsoft.Kiota.Abstractions.Tests/RequestHeadersTests.cs
+++ b/Microsoft.Kiota.Abstractions.Tests/RequestHeadersTests.cs
@@ -42,7 +42,7 @@ public class RequestHeadersTests {
         instance.Remove("name", "value");
         Assert.Equal(new [] { "value2" }, instance["name"]);
         instance.Remove("name", "value2");
-        Assert.Null(instance["name"]);
+        Assert.Throws<KeyNotFoundException>(() => instance["name"]);
     }
     [Fact]
     public void Removes() {
@@ -50,7 +50,7 @@ public class RequestHeadersTests {
         instance.Add("name", "value");
         instance.Add("name", "value2");
         Assert.True(instance.Remove("name"));
-        Assert.Null(instance["name"]);
+        Assert.Throws<KeyNotFoundException>(() => instance["name"]);
         Assert.False(instance.Remove("name"));
     }
     [Fact]
@@ -59,7 +59,7 @@ public class RequestHeadersTests {
         instance.Add("name", "value");
         instance.Add("name", "value2");
         Assert.True(instance.Remove(new KeyValuePair<string, IEnumerable<string>>("name", new [] { "value", "value2" })));
-        Assert.Null(instance["name"]);
+        Assert.Throws<KeyNotFoundException>(() => instance["name"]);
         Assert.False(instance.Remove("name"));
     }
     [Fact]
@@ -68,7 +68,8 @@ public class RequestHeadersTests {
         instance.Add("name", "value");
         instance.Add("name", "value2");
         instance.Clear();
-        Assert.Null(instance["name"]);
+        Assert.Throws<KeyNotFoundException>(() => instance["name"]);
+        Assert.Empty(instance.Keys);
     }
     [Fact]
     public void GetsEnumerator() {

--- a/src/IRequestAdapter.cs
+++ b/src/IRequestAdapter.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -32,7 +32,7 @@ namespace Microsoft.Kiota.Abstractions
         /// <param name="errorMapping">The error factories mapping to use in case of a failed request.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use for cancelling the requests.</param>
         /// <returns>The deserialized response model.</returns>
-        Task<ModelType> SendAsync<ModelType>(RequestInformation requestInfo, ParsableFactory<ModelType> factory, Dictionary<string, ParsableFactory<IParsable>> errorMapping = default, CancellationToken cancellationToken = default) where ModelType : IParsable;
+        Task<ModelType?> SendAsync<ModelType>(RequestInformation requestInfo, ParsableFactory<ModelType> factory, Dictionary<string, ParsableFactory<IParsable>>? errorMapping = default, CancellationToken cancellationToken = default) where ModelType : IParsable;
         /// <summary>
         /// Executes the HTTP request specified by the given RequestInformation and returns the deserialized response model collection.
         /// </summary>
@@ -41,7 +41,7 @@ namespace Microsoft.Kiota.Abstractions
         /// <param name="errorMapping">The error factories mapping to use in case of a failed request.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use for cancelling the requests.</param>
         /// <returns>The deserialized response model collection.</returns>
-        Task<IEnumerable<ModelType>> SendCollectionAsync<ModelType>(RequestInformation requestInfo, ParsableFactory<ModelType> factory, Dictionary<string, ParsableFactory<IParsable>> errorMapping = default, CancellationToken cancellationToken = default) where ModelType : IParsable;
+        Task<IEnumerable<ModelType>?> SendCollectionAsync<ModelType>(RequestInformation requestInfo, ParsableFactory<ModelType> factory, Dictionary<string, ParsableFactory<IParsable>>? errorMapping = default, CancellationToken cancellationToken = default) where ModelType : IParsable;
         /// <summary>
         /// Executes the HTTP request specified by the given RequestInformation and returns the deserialized primitive response model.
         /// </summary>
@@ -49,7 +49,7 @@ namespace Microsoft.Kiota.Abstractions
         /// <param name="errorMapping">The error factories mapping to use in case of a failed request.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use for cancelling the requests.</param>
         /// <returns>The deserialized primitive response model.</returns>
-        Task<ModelType> SendPrimitiveAsync<ModelType>(RequestInformation requestInfo, Dictionary<string, ParsableFactory<IParsable>> errorMapping = default, CancellationToken cancellationToken = default);
+        Task<ModelType?> SendPrimitiveAsync<ModelType>(RequestInformation requestInfo, Dictionary<string, ParsableFactory<IParsable>>? errorMapping = default, CancellationToken cancellationToken = default);
         /// <summary>
         /// Executes the HTTP request specified by the given RequestInformation and returns the deserialized primitive response model collection.
         /// </summary>
@@ -57,7 +57,7 @@ namespace Microsoft.Kiota.Abstractions
         /// <param name="errorMapping">The error factories mapping to use in case of a failed request.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use for cancelling the requests.</param>
         /// <returns>The deserialized primitive response model collection.</returns>
-        Task<IEnumerable<ModelType>> SendPrimitiveCollectionAsync<ModelType>(RequestInformation requestInfo, Dictionary<string, ParsableFactory<IParsable>> errorMapping = default, CancellationToken cancellationToken = default);
+        Task<IEnumerable<ModelType>?> SendPrimitiveCollectionAsync<ModelType>(RequestInformation requestInfo, Dictionary<string, ParsableFactory<IParsable>>? errorMapping = default, CancellationToken cancellationToken = default);
         /// <summary>
         /// Executes the HTTP request specified by the given RequestInformation with no return content.
         /// </summary>
@@ -65,11 +65,11 @@ namespace Microsoft.Kiota.Abstractions
         /// <param name="errorMapping">The error factories mapping to use in case of a failed request.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use for cancelling the requests.</param>
         /// <returns>A Task to await completion.</returns>
-        Task SendNoContentAsync(RequestInformation requestInfo, Dictionary<string, ParsableFactory<IParsable>> errorMapping = default, CancellationToken cancellationToken = default);
+        Task SendNoContentAsync(RequestInformation requestInfo, Dictionary<string, ParsableFactory<IParsable>>? errorMapping = default, CancellationToken cancellationToken = default);
         /// <summary>
         /// The base url for every request.
         /// </summary>
-        string BaseUrl { get; set; }
+        string? BaseUrl { get; set; }
         /// <summary>
         /// Converts the given RequestInformation into a native HTTP request used by the implementing adapter.
         /// </summary>
@@ -77,6 +77,6 @@ namespace Microsoft.Kiota.Abstractions
         /// <param name="requestInfo">The RequestInformation object to use for the HTTP request.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use for cancelling the requests.</param>
         /// <returns>The native HTTP request.</returns>
-        Task<T> ConvertToNativeRequestAsync<T>(RequestInformation requestInfo, CancellationToken cancellationToken = default);
+        Task<T?> ConvertToNativeRequestAsync<T>(RequestInformation requestInfo, CancellationToken cancellationToken = default);
     }
 }

--- a/src/IResponseHandler.cs
+++ b/src/IResponseHandler.cs
@@ -22,6 +22,6 @@ namespace Microsoft.Kiota.Abstractions
         /// <typeparam name="NativeResponseType">The type of the native response object.</typeparam>
         /// <typeparam name="ModelType">The type of the response model object.</typeparam>
         /// <returns>A task that represents the asynchronous operation and contains the deserialized response.</returns>
-        Task<ModelType> HandleResponseAsync<NativeResponseType, ModelType>(NativeResponseType response, Dictionary<string, ParsableFactory<IParsable>> errorMappings);
+        Task<ModelType?> HandleResponseAsync<NativeResponseType, ModelType>(NativeResponseType response, Dictionary<string, ParsableFactory<IParsable>>? errorMappings);
     }
 }

--- a/src/Microsoft.Kiota.Abstractions.csproj
+++ b/src/Microsoft.Kiota.Abstractions.csproj
@@ -6,7 +6,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>Kiota Abstractions Library for dotnet</AssemblyTitle>
     <Authors>Microsoft</Authors>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0;</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota-abstractions-dotnet</RepositoryUrl>
@@ -14,12 +14,15 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>rc.3</VersionSuffix>
+    <VersionSuffix>rc.4</VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <SignAssembly>false</SignAssembly>
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <!-- Enable this line once we go live to prevent breaking changes -->
     <!-- <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> -->
     <PackageReleaseNotes>

--- a/src/Microsoft.Kiota.Abstractions.csproj
+++ b/src/Microsoft.Kiota.Abstractions.csproj
@@ -6,7 +6,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>Kiota Abstractions Library for dotnet</AssemblyTitle>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard2.0;net6.0;</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota-abstractions-dotnet</RepositoryUrl>

--- a/src/NativeResponseHandler.cs
+++ b/src/NativeResponseHandler.cs
@@ -17,17 +17,17 @@ namespace Microsoft.Kiota.Abstractions
         /// <summary>
         /// The value of the response
         /// </summary>
-        public object Value;
+        public object? Value;
 
         /// <summary>
         /// The error mappings for the response to use when deserializing failed responses bodies. Where an error code like 401 applies specifically to that status code, a class code like 4XX applies to all status codes within the range if an the specific error code is not present.
         /// </summary>
-        public Dictionary<string, ParsableFactory<IParsable>> ErrorMappings { get; set; }
+        public Dictionary<string, ParsableFactory<IParsable>>? ErrorMappings { get; set; }
 
         /// <inheritdoc />
-        public Task<ModelType> HandleResponseAsync<NativeResponseType, ModelType>(NativeResponseType response, Dictionary<string, ParsableFactory<IParsable>> errorMappings)
+        public Task<ModelType?> HandleResponseAsync<NativeResponseType, ModelType>(NativeResponseType response, Dictionary<string, ParsableFactory<IParsable>>? errorMappings)
         {
-            Value = response;
+            Value = response ?? throw new ArgumentNullException(nameof(response));
             ErrorMappings = errorMappings;
             return Task.FromResult(default(ModelType));
         }

--- a/src/NativeResponseWrapper.cs
+++ b/src/NativeResponseWrapper.cs
@@ -22,11 +22,11 @@ namespace Microsoft.Kiota.Abstractions
         /// <param name="h">The request headers of the request</param>
         /// <param name="o">Request options</param>
         /// <returns></returns>
-        public static async Task<NativeResponseType> CallAndGetNativeType<ModelType, NativeResponseType, QueryParametersType>(
-                Func<Action<QueryParametersType>, Action<IDictionary<string, string>>, IEnumerable<IRequestOption>, IResponseHandler, Task<ModelType>> originalCall,
-                Action<QueryParametersType> q = default,
-                Action<IDictionary<string, string>> h = default,
-                IEnumerable<IRequestOption> o = default) where NativeResponseType : class
+        public static async Task<NativeResponseType?> CallAndGetNativeType<ModelType, NativeResponseType, QueryParametersType>(
+                Func<Action<QueryParametersType>?, Action<IDictionary<string, string>>?, IEnumerable<IRequestOption>?, IResponseHandler, Task<ModelType>> originalCall,
+                Action<QueryParametersType>? q = default,
+                Action<IDictionary<string, string>>? h = default,
+                IEnumerable<IRequestOption>? o = default) where NativeResponseType : class
         {
             var responseHandler = new NativeResponseHandler();
             await originalCall.Invoke(q, h, o, responseHandler);
@@ -42,12 +42,12 @@ namespace Microsoft.Kiota.Abstractions
         /// <param name="q">The query parameters of the request</param>
         /// <param name="h">The request headers of the request</param>
         /// <param name="o">Request options</param>
-        public static async Task<NativeResponseType> CallAndGetNativeType<ModelType, NativeResponseType, QueryParametersType, RequestBodyType>(
-                Func<RequestBodyType, Action<QueryParametersType>, Action<IDictionary<string, string>>, IEnumerable<IRequestOption>, IResponseHandler, Task<ModelType>> originalCall,
+        public static async Task<NativeResponseType?> CallAndGetNativeType<ModelType, NativeResponseType, QueryParametersType, RequestBodyType>(
+                Func<RequestBodyType, Action<QueryParametersType>?, Action<IDictionary<string, string>>?, IEnumerable<IRequestOption>?, IResponseHandler, Task<ModelType>> originalCall,
                 RequestBodyType requestBody,
-                Action<QueryParametersType> q = default,
-                Action<IDictionary<string, string>> h = default,
-                IEnumerable<IRequestOption> o = default) where NativeResponseType : class
+                Action<QueryParametersType>? q = default,
+                Action<IDictionary<string, string>>? h = default,
+                IEnumerable<IRequestOption>? o = default) where NativeResponseType : class
         {
             var responseHandler = new NativeResponseHandler();
             await originalCall.Invoke(requestBody, q, h, o, responseHandler);

--- a/src/RequestHeaders.cs
+++ b/src/RequestHeaders.cs
@@ -35,7 +35,9 @@ public class RequestHeaders : IDictionary<string,IEnumerable<string>> {
     /// <inheritdoc/>
     public bool IsReadOnly => false;
     /// <inheritdoc/>
+#pragma warning disable CS8603 // Possible null reference return. //Can't change signature of overriden method implementation
     public IEnumerable<string> this[string key] { get => TryGetValue(key, out var result) ? result : null; set => Add(key, value); }
+#pragma warning restore CS8603 // Possible null reference return.
 
     /// <summary>
     /// Removes the specified value from the header with the specified name.
@@ -75,7 +77,9 @@ public class RequestHeaders : IDictionary<string,IEnumerable<string>> {
     /// <inheritdoc/>
     public bool ContainsKey(string key) => !string.IsNullOrEmpty(key) && _headers.ContainsKey(key);
     /// <inheritdoc/>
+#pragma warning disable CS8604 // Possible null reference argument. //Can't change signature of overriden method implementation
     public void Add(string key, IEnumerable<string> value) => Add(key, value?.ToArray());
+#pragma warning restore CS8604 // Possible null reference argument.
     /// <inheritdoc/>
     public bool Remove(string key) {
         if(string.IsNullOrEmpty(key))

--- a/src/RequestHeaders.cs
+++ b/src/RequestHeaders.cs
@@ -35,9 +35,7 @@ public class RequestHeaders : IDictionary<string,IEnumerable<string>> {
     /// <inheritdoc/>
     public bool IsReadOnly => false;
     /// <inheritdoc/>
-#pragma warning disable CS8603 // Possible null reference return. //Can't change signature of overriden method implementation
-    public IEnumerable<string> this[string key] { get => TryGetValue(key, out var result) ? result : null; set => Add(key, value); }
-#pragma warning restore CS8603 // Possible null reference return.
+    public IEnumerable<string> this[string key] { get => TryGetValue(key, out var result) ? result : throw new KeyNotFoundException($"Key not found : {key}"); set => Add(key, value); }
 
     /// <summary>
     /// Removes the specified value from the header with the specified name.

--- a/src/RequestInformation.cs
+++ b/src/RequestInformation.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -19,7 +19,7 @@ namespace Microsoft.Kiota.Abstractions
     /// </summary>
     public class RequestInformation
     {
-        private Uri _rawUri;
+        private Uri? _rawUri;
         /// <summary>
         ///  The URI of the request.
         /// </summary>
@@ -37,11 +37,11 @@ namespace Microsoft.Kiota.Abstractions
                 else if(PathParameters.TryGetValue("request-raw-url", out var rawUrl) &&
                     rawUrl is string rawUrlString) {
                     URI = new Uri(rawUrlString);
-                    return _rawUri;
+                    return _rawUri!;
                 }
                 else
                 {
-                    if(UrlTemplate.IndexOf("{+baseurl}", StringComparison.OrdinalIgnoreCase) >= 0 && !PathParameters.ContainsKey("baseurl"))
+                    if(UrlTemplate?.IndexOf("{+baseurl}", StringComparison.OrdinalIgnoreCase) >= 0 && !PathParameters.ContainsKey("baseurl"))
                         throw new InvalidOperationException($"{nameof(PathParameters)} must contain a value for \"baseurl\" for the url to be built.");
 
                     var parsedUrlTemplate = new UriTemplate(UrlTemplate);
@@ -78,7 +78,7 @@ namespace Microsoft.Kiota.Abstractions
         /// <summary>
         /// The Url template for the current request.
         /// </summary>
-        public string UrlTemplate { get; set; }
+        public string? UrlTemplate { get; set; }
         /// <summary>
         /// The path parameters to use for the URL template when generating the URI.
         /// </summary>
@@ -109,11 +109,11 @@ namespace Microsoft.Kiota.Abstractions
                                             )
                                         )
                                         .Where(x =>  x.Value != null &&
-                                                    !QueryParameters.ContainsKey(x.Name) &&
+                                                    !QueryParameters.ContainsKey(x.Name!) &&
                                                     !string.IsNullOrEmpty(x.Value.ToString()) && // no need to add an empty string value
                                                     (x.Value is not ICollection collection || collection.Count > 0))) // no need to add empty collection
             {
-                QueryParameters.AddOrReplace(property.Name, property.Value);
+                QueryParameters.AddOrReplace(property.Name!, property.Value!);
             }
         }
         /// <summary>
@@ -130,7 +130,7 @@ namespace Microsoft.Kiota.Abstractions
         /// <summary>
         /// The Request Body.
         /// </summary>
-        public Stream Content { get; set; }
+        public Stream Content { get; set; } = Stream.Null;
         private readonly Dictionary<string, IRequestOption> _requestOptions = new Dictionary<string, IRequestOption>(StringComparer.OrdinalIgnoreCase);
         /// <summary>
         /// Gets the options for this request. Options are unique by type. If an option of the same type is added twice, the last one wins.
@@ -144,7 +144,7 @@ namespace Microsoft.Kiota.Abstractions
         {
             if(options == null) return;
             foreach(var option in options.Where(x => x != null))
-                _requestOptions.AddOrReplace(option.GetType().FullName, option);
+                _requestOptions.AddOrReplace(option.GetType().FullName!, option);
         }
         /// <summary>
         /// Removes given options from the current request.
@@ -153,14 +153,14 @@ namespace Microsoft.Kiota.Abstractions
         public void RemoveRequestOptions(params IRequestOption[] options)
         {
             if(!options?.Any() ?? false) throw new ArgumentNullException(nameof(options));
-            foreach(var optionName in options.Where(x => x != null).Select(x => x.GetType().FullName))
-                _requestOptions.Remove(optionName);
+            foreach(var optionName in options!.Where(x => x != null).Select(x => x.GetType().FullName))
+                _requestOptions.Remove(optionName!);
         }
 
         /// <summary>
         /// Gets a <see cref="IRequestOption"/> instance of the matching type.
         /// </summary>
-        public T GetRequestOption<T>() => _requestOptions.TryGetValue(typeof(T).FullName, out var requestOption) ? (T)requestOption : default;
+        public T? GetRequestOption<T>() => _requestOptions.TryGetValue(typeof(T).FullName!, out var requestOption) ? (T)requestOption : default;
 
         /// <summary>
         /// Adds a <see cref="IResponseHandler"/> as a <see cref="IRequestOption"/> for the request.
@@ -190,7 +190,7 @@ namespace Microsoft.Kiota.Abstractions
             Content = content;
             Headers.Add(ContentTypeHeader, BinaryContentType);
         }
-        private static ActivitySource _activitySource = new(typeof(RequestInformation).Namespace);
+        private static ActivitySource _activitySource = new(typeof(RequestInformation).Namespace!);
         /// <summary>
         /// Sets the request body from a model with the specified content type.
         /// </summary>
@@ -223,7 +223,8 @@ namespace Microsoft.Kiota.Abstractions
             Headers.Add(ContentTypeHeader, contentType);
             Content = writer.GetSerializedContent();
         }
-        private void setRequestType(object result, Activity activity) {
+        private void setRequestType(object? result, Activity? activity)
+        {
             if (activity == null) return;
             if (result == null) return;
             activity.SetTag("com.microsoft.kiota.request.type", result.GetType().FullName);

--- a/src/RequestInformation.cs
+++ b/src/RequestInformation.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Kiota.Abstractions
         /// </summary>
         /// <param name="value">Object to be sanitized</param>
         /// <returns>Sanitized object</returns>
-        private object GetSanitizedValue(object value) => value switch
+        private static object GetSanitizedValue(object value) => value switch
         {
             bool boolean => boolean.ToString().ToLower(),// pass in a lowercase string as the final url will be uppercase due to the way ToString() works for booleans
             DateTimeOffset dateTimeOffset => dateTimeOffset.ToString("o"),// Default to ISO 8601 for datetimeoffsets in the url.
@@ -186,7 +186,7 @@ namespace Microsoft.Kiota.Abstractions
         public void SetStreamContent(Stream content)
         {
             using var activity = _activitySource?.StartActivity(nameof(SetStreamContent));
-            setRequestType(content, activity);
+            SetRequestType(content, activity);
             Content = content;
             Headers.Add(ContentTypeHeader, BinaryContentType);
         }
@@ -201,8 +201,8 @@ namespace Microsoft.Kiota.Abstractions
         public void SetContentFromParsable<T>(IRequestAdapter requestAdapter, string contentType, IEnumerable<T> items) where T : IParsable
         {
             using var activity = _activitySource?.StartActivity(nameof(SetContentFromParsable));
-            using var writer = getSerializationWriter(requestAdapter, contentType, items);
-            setRequestType(items.FirstOrDefault(static x => x != null), activity);
+            using var writer = GetSerializationWriter(requestAdapter, contentType, items);
+            SetRequestType(items.FirstOrDefault(static x => x != null), activity);
             writer.WriteCollectionOfObjectValues(null, items);
             Headers.Add(ContentTypeHeader, contentType);
             Content = writer.GetSerializedContent();
@@ -217,19 +217,19 @@ namespace Microsoft.Kiota.Abstractions
         public void SetContentFromParsable<T>(IRequestAdapter requestAdapter, string contentType, T item) where T : IParsable
         {
             using var activity = _activitySource?.StartActivity(nameof(SetContentFromParsable));
-            using var writer = getSerializationWriter(requestAdapter, contentType, item);
-            setRequestType(item, activity);
+            using var writer = GetSerializationWriter(requestAdapter, contentType, item);
+            SetRequestType(item, activity);
             writer.WriteObjectValue(null, item);
             Headers.Add(ContentTypeHeader, contentType);
             Content = writer.GetSerializedContent();
         }
-        private void setRequestType(object? result, Activity? activity)
+        private static void SetRequestType(object? result, Activity? activity)
         {
             if (activity == null) return;
             if (result == null) return;
             activity.SetTag("com.microsoft.kiota.request.type", result.GetType().FullName);
         }
-        private ISerializationWriter getSerializationWriter<T>(IRequestAdapter requestAdapter, string contentType, T item)
+        private static ISerializationWriter GetSerializationWriter<T>(IRequestAdapter requestAdapter, string contentType, T item)
         {
             if(string.IsNullOrEmpty(contentType)) throw new ArgumentNullException(nameof(contentType));
             if(requestAdapter == null) throw new ArgumentNullException(nameof(requestAdapter));
@@ -246,8 +246,8 @@ namespace Microsoft.Kiota.Abstractions
         public void SetContentFromScalarCollection<T>(IRequestAdapter requestAdapter, string contentType, IEnumerable<T> items)
         {
             using var activity = _activitySource?.StartActivity(nameof(SetContentFromScalarCollection));
-            using var writer = getSerializationWriter(requestAdapter, contentType, items);
-            setRequestType(items.FirstOrDefault(static x => x != null), activity);
+            using var writer = GetSerializationWriter(requestAdapter, contentType, items);
+            SetRequestType(items.FirstOrDefault(static x => x != null), activity);
             writer.WriteCollectionOfPrimitiveValues(null, items);
             Headers.Add(ContentTypeHeader, contentType);
             Content = writer.GetSerializedContent();
@@ -262,8 +262,8 @@ namespace Microsoft.Kiota.Abstractions
         public void SetContentFromScalar<T>(IRequestAdapter requestAdapter, string contentType, T item)
         {
             using var activity = _activitySource?.StartActivity(nameof(SetContentFromScalar));
-            using var writer = getSerializationWriter(requestAdapter, contentType, item);
-            setRequestType(item, activity);
+            using var writer = GetSerializationWriter(requestAdapter, contentType, item);
+            SetRequestType(item, activity);
             switch(item)
             {
                 case string s:

--- a/src/ResponseHandlerOption.cs
+++ b/src/ResponseHandlerOption.cs
@@ -12,6 +12,6 @@ namespace Microsoft.Kiota.Abstractions
         /// <summary>
         /// The <see cref="IResponseHandler"/> to use for a request
         /// </summary>
-        public IResponseHandler ResponseHandler { get; set; }
+        public IResponseHandler? ResponseHandler { get; set; }
     }
 }

--- a/src/authentication/AllowedHostsValidator.cs
+++ b/src/authentication/AllowedHostsValidator.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Kiota.Abstractions.Authentication
         /// The <see cref="AllowedHostsValidator"/> constructor
         /// </summary>
         /// <param name="validHosts"> Collection of valid Hosts</param>
-        public AllowedHostsValidator(IEnumerable<string> validHosts = null)
+        public AllowedHostsValidator(IEnumerable<string>? validHosts = null)
         {
             _allowedHosts = new HashSet<string>(validHosts ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
         }

--- a/src/authentication/AnonymousAuthenticationProvider.cs
+++ b/src/authentication/AnonymousAuthenticationProvider.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -14,7 +14,7 @@ namespace Microsoft.Kiota.Abstractions.Authentication
     public class AnonymousAuthenticationProvider : IAuthenticationProvider
     {
         /// <inheritdoc />
-        public Task AuthenticateRequestAsync(RequestInformation request, Dictionary<string, object> additionalAuthenticationContext = default, CancellationToken cancellationToken = default)
+        public Task AuthenticateRequestAsync(RequestInformation request, Dictionary<string, object>? additionalAuthenticationContext = default, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }

--- a/src/authentication/ApiKeyAuthenticationProvider.cs
+++ b/src/authentication/ApiKeyAuthenticationProvider.cs
@@ -41,9 +41,10 @@ public class ApiKeyAuthenticationProvider : IAuthenticationProvider
         KeyLoc = keyLocation;
         AllowedHostsValidator = new AllowedHostsValidator(allowedHosts);
     }
-    private static ActivitySource _activitySource = new(typeof(RequestInformation).Namespace);
+    private static ActivitySource _activitySource = new(typeof(RequestInformation).Namespace!);
     /// <inheritdoc />
-    public Task AuthenticateRequestAsync(RequestInformation request, Dictionary<string, object> additionalAuthenticationContext = null, CancellationToken cancellationToken = default) {
+    public Task AuthenticateRequestAsync(RequestInformation request, Dictionary<string, object>? additionalAuthenticationContext = default, CancellationToken cancellationToken = default)
+    {
         if (request == null)
             throw new ArgumentNullException(nameof(request));
         using var span = _activitySource?.StartActivity(nameof(AuthenticateRequestAsync));

--- a/src/authentication/BaseBearerTokenAuthenticationProvider.cs
+++ b/src/authentication/BaseBearerTokenAuthenticationProvider.cs
@@ -29,7 +29,7 @@ public class BaseBearerTokenAuthenticationProvider : IAuthenticationProvider
     private const string ClaimsKey = "claims";
 
     /// <inheritdoc />
-    public async Task AuthenticateRequestAsync(RequestInformation request, Dictionary<string, object> additionalAuthenticationContext = default, CancellationToken cancellationToken = default)
+    public async Task AuthenticateRequestAsync(RequestInformation request, Dictionary<string, object>? additionalAuthenticationContext = default, CancellationToken cancellationToken = default)
     {
         if(request == null) throw new ArgumentNullException(nameof(request));
         if(additionalAuthenticationContext != null &&

--- a/src/authentication/IAccessTokenProvider.cs
+++ b/src/authentication/IAccessTokenProvider.cs
@@ -20,7 +20,7 @@ public interface IAccessTokenProvider
     /// <param name="additionalAuthenticationContext">Additional authentication context to pass to the authentication library.</param>
     /// <param name="cancellationToken">The cancellation token for the task</param>
     /// <returns>A Task that holds the access token to use for the request.</returns>
-    Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object> additionalAuthenticationContext = default, CancellationToken cancellationToken = default);
+    Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object>? additionalAuthenticationContext = default, CancellationToken cancellationToken = default);
     /// <summary>
     /// Returns the <see cref="AllowedHostsValidator"/> for the provider.
     /// </summary>

--- a/src/authentication/IAuthenticationProvider.cs
+++ b/src/authentication/IAuthenticationProvider.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -20,6 +20,6 @@ namespace Microsoft.Kiota.Abstractions.Authentication
         /// <param name="additionalAuthenticationContext">Additional authentication context to pass to the authentication library.</param>
         /// <param name="cancellationToken">The cancellation token for the task</param>
         /// <returns>A task to await for the authentication to be completed.</returns>
-        Task AuthenticateRequestAsync(RequestInformation request, Dictionary<string, object> additionalAuthenticationContext = default, CancellationToken cancellationToken = default);
+        Task AuthenticateRequestAsync(RequestInformation request, Dictionary<string, object>? additionalAuthenticationContext = default, CancellationToken cancellationToken = default);
     }
 }

--- a/src/extensions/IDictionaryExtensions.cs
+++ b/src/extensions/IDictionaryExtensions.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -51,7 +51,7 @@ namespace Microsoft.Kiota.Abstractions.Extensions
         /// <param name="key">The key parameter.</param>
         /// <param name="value">The value</param>
         /// <returns>The previous value if any</returns>
-        public static TValue AddOrReplace<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue value)
+        public static TValue? AddOrReplace<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue value)
         {
             if(!dictionary.TryAdd(key, value))
             {

--- a/src/extensions/StringExtensions.cs
+++ b/src/extensions/StringExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Kiota.Abstractions.Extensions
         /// </summary>
         /// <param name="input">The string to lowercase.</param>
         /// <returns>The input string with the first letter lowered.</returns>
-        public static string ToFirstCharacterLowerCase(this string input)
-            => string.IsNullOrEmpty(input) ? input : $"{char.ToLowerInvariant(input[0])}{input.Substring(1)}";
+        public static string? ToFirstCharacterLowerCase(this string? input)
+            => string.IsNullOrEmpty(input) ? input : $"{char.ToLowerInvariant(input![0])}{input.Substring(1)}";
     }
 }

--- a/src/serialization/IParseNode.cs
+++ b/src/serialization/IParseNode.cs
@@ -16,13 +16,13 @@ namespace Microsoft.Kiota.Abstractions.Serialization
         ///  Gets the string value of the node.
         /// </summary>
         /// <returns>The string value of the node.</returns>
-        string GetStringValue();
+        string? GetStringValue();
         /// <summary>
         ///  Gets a new parse node for the given identifier.
         /// </summary>
         /// <param name="identifier">The identifier.</param>
         /// <returns>The new parse node.</returns>
-        IParseNode GetChildNode(string identifier);
+        IParseNode? GetChildNode(string identifier);
         /// <summary>
         ///  Gets the boolean value of the node.
         /// </summary>
@@ -114,19 +114,19 @@ namespace Microsoft.Kiota.Abstractions.Serialization
         /// </summary>
         /// <param name="factory">The factory to use to create the model object.</param>
         /// <returns>The model object value of the node.</returns>
-        T GetObjectValue<T>(ParsableFactory<T> factory) where T : IParsable;
+        T? GetObjectValue<T>(ParsableFactory<T> factory) where T : IParsable;
         /// <summary>
         /// Callback called before the node is deserialized.
         /// </summary>
-        Action<IParsable> OnBeforeAssignFieldValues { get; set; }
+        Action<IParsable>? OnBeforeAssignFieldValues { get; set; }
         /// <summary>
         /// Callback called after the node is deserialized.
         /// </summary>
-        Action<IParsable> OnAfterAssignFieldValues { get; set; }
+        Action<IParsable>? OnAfterAssignFieldValues { get; set; }
         /// <summary>
         /// Gets the byte array value of the node.
         /// </summary>
         /// <returns>The byte array value of the node.</returns>
-        byte[] GetByteArrayValue();
+        byte[]? GetByteArrayValue();
     }
 }

--- a/src/serialization/ISerializationWriter.cs
+++ b/src/serialization/ISerializationWriter.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -18,127 +18,127 @@ namespace Microsoft.Kiota.Abstractions.Serialization
         /// </summary>
         /// <param name="key">The key to be used for the written value. May be null.</param>
         /// <param name="value">The string value to be written.</param>
-        void WriteStringValue(string key, string value);
+        void WriteStringValue(string? key, string? value);
         /// <summary>
         /// Writes the specified boolean value to the stream with an optional given key. 
         /// </summary>
         /// <param name="key">The key to be used for the written value. May be null.</param>
         /// <param name="value">The byte boolean value to be written.</param>
-        void WriteBoolValue(string key, bool? value);
+        void WriteBoolValue(string? key, bool? value);
         /// <summary>
         /// Writes the specified byte value to the stream with an optional given key. 
         /// </summary>
         /// <param name="key">The key to be used for the written value. May be null.</param>
         /// <param name="value">The byte value to be written.</param>
-        void WriteByteValue(string key, byte? value);
+        void WriteByteValue(string? key, byte? value);
         /// <summary>
         /// Writes the specified sbyte value to the stream with an optional given key. 
         /// </summary>
         /// <param name="key">The key to be used for the written value. May be null.</param>
         /// <param name="value">The sbyte value to be written.</param>
-        void WriteSbyteValue(string key, sbyte? value);
+        void WriteSbyteValue(string? key, sbyte? value);
         /// <summary>
         /// Writes the specified byte integer value to the stream with an optional given key.
         /// </summary>
         /// <param name="key">The key to be used for the written value. May be null.</param>
         /// <param name="value">The byte integer value to be written.</param>
-        void WriteIntValue(string key, int? value);
+        void WriteIntValue(string? key, int? value);
         /// <summary>
         /// Writes the specified float value to the stream with an optional given key.
         /// </summary>
         /// <param name="key">The key to be used for the written value. May be null.</param>
         /// <param name="value">The float value to be written.</param>
-        void WriteFloatValue(string key, float? value);
+        void WriteFloatValue(string? key, float? value);
         /// <summary>
         /// Writes the specified long value to the stream with an optional given key.
         /// </summary>
         /// <param name="key">The key to be used for the written value. May be null.</param>
         /// <param name="value">The long value to be written.</param>
-        void WriteLongValue(string key, long? value);
+        void WriteLongValue(string? key, long? value);
         /// <summary>
         /// Writes the specified double value to the stream with an optional given key.
         /// </summary>
         /// <param name="key">The key to be used for the written value. May be null.</param>
         /// <param name="value">The double value to be written.</param>
-        void WriteDoubleValue(string key, double? value);
+        void WriteDoubleValue(string? key, double? value);
         /// <summary>
         /// Writes the specified decimal value to the stream with an optional given key.
         /// </summary>
         /// <param name="key">The key to be used for the written value. May be null.</param>
         /// <param name="value">The decimal value to be written.</param>
-        void WriteDecimalValue(string key, decimal? value);
+        void WriteDecimalValue(string? key, decimal? value);
         /// <summary>
         /// Writes the specified Guid value to the stream with an optional given key.
         /// </summary>
         /// <param name="key">The key to be used for the written value. May be null.</param>
         /// <param name="value">The Guid value to be written.</param>
-        void WriteGuidValue(string key, Guid? value);
+        void WriteGuidValue(string? key, Guid? value);
         /// <summary>
         /// Writes the specified DateTimeOffset value to the stream with an optional given key.
         /// </summary>
         /// <param name="key">The key to be used for the written value. May be null.</param>
         /// <param name="value">The DateTimeOffset value to be written.</param>
-        void WriteDateTimeOffsetValue(string key, DateTimeOffset? value);
+        void WriteDateTimeOffsetValue(string? key, DateTimeOffset? value);
         /// <summary>
         /// Writes the specified TimeSpan value to the stream with an optional given key.
         /// </summary>
         /// <param name="key">The key to be used for the written value. May be null.</param>
         /// <param name="value">The TimeSpan value to be written.</param>
-        void WriteTimeSpanValue(string key, TimeSpan? value);
+        void WriteTimeSpanValue(string? key, TimeSpan? value);
         /// <summary>
         /// Writes the specified Date value to the stream with an optional given key.
         /// </summary>
         /// <param name="key">The key to be used for the written value. May be null.</param>
         /// <param name="value">The Date value to be written.</param>
-        void WriteDateValue(string key, Date? value);
+        void WriteDateValue(string? key, Date? value);
         /// <summary>
         /// Writes the specified Time value to the stream with an optional given key.
         /// </summary>
         /// <param name="key">The key to be used for the written value. May be null.</param>
         /// <param name="value">The Time value to be written.</param>
-        void WriteTimeValue(string key, Time? value);
+        void WriteTimeValue(string? key, Time? value);
         /// <summary>
         /// Writes the specified collection of primitive values to the stream with an optional given key.
         /// </summary>
         /// <param name="key">The key to be used for the written value. May be null.</param>
         /// <param name="values">The collection of primitive values to be written.</param>
-        void WriteCollectionOfPrimitiveValues<T>(string key, IEnumerable<T> values);
+        void WriteCollectionOfPrimitiveValues<T>(string? key, IEnumerable<T>? values);
         /// <summary>
         /// Writes the specified collection of model objects to the stream with an optional given key.
         /// </summary>
         /// <param name="key">The key to be used for the written value. May be null.</param>
         /// <param name="values">The collection of model objects to be written.</param>
-        void WriteCollectionOfObjectValues<T>(string key, IEnumerable<T> values) where T : IParsable;
+        void WriteCollectionOfObjectValues<T>(string? key, IEnumerable<T>? values) where T : IParsable;
         /// <summary>
         /// Writes the specified collection of enum values to the stream with an optional given key.
         /// </summary>
         /// <param name="key">The key to be used for the written value. May be null.</param>
         /// <param name="values">The enum values to be written.</param>
-        void WriteCollectionOfEnumValues<T>(string key, IEnumerable<T?> values) where T : struct, Enum;
+        void WriteCollectionOfEnumValues<T>(string? key, IEnumerable<T?>? values) where T : struct, Enum;
         /// <summary>
         /// Writes the specified byte array as a base64 string to the stream with an optional given key.
         /// </summary>
         /// <param name="key">The key to be used for the written value. May be null.</param>
         /// <param name="value">The byte array to be written.</param>
-        void WriteByteArrayValue(string key, byte[] value);
+        void WriteByteArrayValue(string? key, byte[]? value);
         /// <summary>
         /// Writes the specified model object to the stream with an optional given key.
         /// </summary>
         /// <param name="key">The key to be used for the written value. May be null.</param>
         /// <param name="value">The model object to be written.</param>
         /// <param name="additionalValuesToMerge">The additional values to merge to the main value when serializing an intersection wrapper.</param>
-        void WriteObjectValue<T>(string key, T value, params IParsable[] additionalValuesToMerge) where T : IParsable;
+        void WriteObjectValue<T>(string? key, T? value, params IParsable[] additionalValuesToMerge) where T : IParsable;
         /// <summary>
         /// Writes the specified enum value to the stream with an optional given key.
         /// </summary>
         /// <param name="key">The key to be used for the written value. May be null.</param>
         /// <param name="value">The enum value to be written.</param>
-        void WriteEnumValue<T>(string key, T? value) where T : struct, Enum;
+        void WriteEnumValue<T>(string? key, T? value) where T : struct, Enum;
         /// <summary>
         /// Writes a null value for the specified key.
         /// </summary>
         /// <param name="key">The key to be used for the written value. May be null.</param>
-        void WriteNullValue(string key);
+        void WriteNullValue(string? key);
         /// <summary>
         /// Writes the specified additional data to the stream.
         /// </summary>
@@ -152,14 +152,14 @@ namespace Microsoft.Kiota.Abstractions.Serialization
         /// <summary>
         /// Callback called before the serialization process starts.
         /// </summary>
-        Action<IParsable> OnBeforeObjectSerialization { get; set; }
+        Action<IParsable>? OnBeforeObjectSerialization { get; set; }
         /// <summary>
         /// Callback called after the serialization process ends.
         /// </summary>
-        Action<IParsable> OnAfterObjectSerialization { get; set; }
+        Action<IParsable>? OnAfterObjectSerialization { get; set; }
         /// <summary>
         /// Callback called right after the serialization process starts.
         /// </summary>
-        Action<IParsable, ISerializationWriter> OnStartObjectSerialization { get; set; }
+        Action<IParsable, ISerializationWriter>? OnStartObjectSerialization { get; set; }
     }
 }

--- a/src/store/IBackingStore.cs
+++ b/src/store/IBackingStore.cs
@@ -15,17 +15,17 @@ namespace Microsoft.Kiota.Abstractions.Store
         /// <summary>Gets a value from the backing store based on its key. Returns null if the value hasn't changed and "ReturnOnlyChangedValues" is true.</summary>
         /// <returns>The value from the backing store.</returns>
         /// <param name="key">The key to lookup the backing store with.</param>
-        T Get<T>(string key);
+        T? Get<T>(string key);
         /// <summary>
         /// Sets or updates the stored value for the given key.
         /// Will trigger subscriptions callbacks.
         /// </summary>
         /// <param name="key">The key to store and retrieve the information.</param>
         /// <param name="value">The value to be stored.</param>
-        void Set<T>(string key, T value);
+        void Set<T>(string key, T? value);
         /// <summary>Enumerates all the values stored in the backing store. Values will be filtered if "ReturnOnlyChangedValues" is true.</summary>
         /// <returns>The values available in the backing store.</returns>
-        IEnumerable<KeyValuePair<string, object>> Enumerate();
+        IEnumerable<KeyValuePair<string, object?>> Enumerate();
         /// <summary>
         /// Enumerates the keys for all values that changed to null.
         /// </summary>
@@ -36,13 +36,13 @@ namespace Microsoft.Kiota.Abstractions.Store
         /// </summary>
         /// <param name="callback">Callback to be invoked on data changes where the first parameter is the data key, the second the previous value and the third the new value.</param>
         /// <returns>The subscription Id to use when removing the subscription</returns>
-        string Subscribe(Action<string, object, object> callback);
+        string Subscribe(Action<string, object?, object?> callback);
         /// <summary>
         /// Creates a subscription to any data change happening, allowing to specify the subscription Id.
         /// </summary>
         /// <param name="callback">Callback to be invoked on data changes where the first parameter is the data key, the second the previous value and the third the new value.</param>
         /// <param name="subscriptionId">The subscription Id to use.</param>
-        void Subscribe(Action<string, object, object> callback, string subscriptionId);
+        void Subscribe(Action<string, object?, object?> callback, string subscriptionId);
         /// <summary>
         /// Removes a subscription from the store based on its subscription id.
         /// </summary>


### PR DESCRIPTION
This PR is part of https://github.com/microsoft/kiota/issues/2073

Changes include: -

- Adds nullable markers to APIs that can return null. 
- Adds nullable feature in project as well as net6.0 target to allow for proper feature functionality. Also sets `TreatWarningsAsErrors` to alleviate any potential mistakes being ignored.