### PR TITLE
Use ConcurrentDictionary for the registries. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.0.0-rc.5] - 2023-01-26
+
+### Changed
+
+- Use concurrent dictionary for serialization registry to avoid race conditions.
+
+### Changed
+
 ## [1.0.0-rc.4] - 2023-01-17
 
 ### Changed

--- a/Microsoft.Kiota.Abstractions.Tests/ApiClientBuilderTests.cs
+++ b/Microsoft.Kiota.Abstractions.Tests/ApiClientBuilderTests.cs
@@ -25,7 +25,26 @@ namespace Microsoft.Kiota.Abstractions.Tests
             // Assert the type has changed due to backing store enabling
             Assert.IsType<BackingStoreSerializationWriterProxyFactory>(serializationFactoryRegistry.ContentTypeAssociatedFactories[StreamContentType]);
         }
-    
+
+        [Fact]
+        public void EnableBackingStoreForSerializationWriterFactoryAlsoEnablesForDefaultInstance()
+        {
+            // Arrange
+            var serializationFactoryRegistry = new SerializationWriterFactoryRegistry();
+            var mockSerializationWriterFactory = new Mock<ISerializationWriterFactory>();
+            serializationFactoryRegistry.ContentTypeAssociatedFactories.TryAdd(StreamContentType, mockSerializationWriterFactory.Object);
+            SerializationWriterFactoryRegistry.DefaultInstance.ContentTypeAssociatedFactories.TryAdd(StreamContentType, mockSerializationWriterFactory.Object);
+
+            Assert.IsNotType<BackingStoreSerializationWriterProxyFactory>(serializationFactoryRegistry.ContentTypeAssociatedFactories[StreamContentType]);
+
+            // Act
+            ApiClientBuilder.EnableBackingStoreForSerializationWriterFactory(serializationFactoryRegistry);
+
+            // Assert the type has changed due to backing store enabling for the default instance as well.
+            Assert.IsType<BackingStoreSerializationWriterProxyFactory>(serializationFactoryRegistry.ContentTypeAssociatedFactories[StreamContentType]);
+            Assert.IsType<BackingStoreSerializationWriterProxyFactory>(SerializationWriterFactoryRegistry.DefaultInstance.ContentTypeAssociatedFactories[StreamContentType]);
+        }
+
         [Fact]
         public void EnableBackingStoreForParseNodeFactory()
         {
@@ -41,6 +60,25 @@ namespace Microsoft.Kiota.Abstractions.Tests
         
             // Assert the type has changed due to backing store enabling
             Assert.IsType<BackingStoreParseNodeFactory>(parseNodeRegistry.ContentTypeAssociatedFactories[StreamContentType]);
+        }
+
+        [Fact]
+        public void EnableBackingStoreForParseNodeFactoryAlsoEnablesForDefaultInstance()
+        {
+            // Arrange
+            var parseNodeRegistry = new ParseNodeFactoryRegistry();
+            var mockParseNodeFactory = new Mock<IParseNodeFactory>();
+            parseNodeRegistry.ContentTypeAssociatedFactories.TryAdd(StreamContentType, mockParseNodeFactory.Object);
+            ParseNodeFactoryRegistry.DefaultInstance.ContentTypeAssociatedFactories.TryAdd(StreamContentType, mockParseNodeFactory.Object);
+
+            Assert.IsNotType<BackingStoreParseNodeFactory>(parseNodeRegistry.ContentTypeAssociatedFactories[StreamContentType]);
+
+            // Act
+            ApiClientBuilder.EnableBackingStoreForParseNodeFactory(parseNodeRegistry);
+
+            // Assert the type has changed due to backing store enabling for the default instance as well.
+            Assert.IsType<BackingStoreParseNodeFactory>(parseNodeRegistry.ContentTypeAssociatedFactories[StreamContentType]);
+            Assert.IsType<BackingStoreParseNodeFactory>(ParseNodeFactoryRegistry.DefaultInstance.ContentTypeAssociatedFactories[StreamContentType]);
         }
     }
 }

--- a/Microsoft.Kiota.Abstractions.Tests/ApiClientBuilderTests.cs
+++ b/Microsoft.Kiota.Abstractions.Tests/ApiClientBuilderTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Kiota.Abstractions.Tests
             // Arrange
             var serializationFactoryRegistry = new SerializationWriterFactoryRegistry();
             var mockSerializationWriterFactory = new Mock<ISerializationWriterFactory>();
-            serializationFactoryRegistry.ContentTypeAssociatedFactories.Add(StreamContentType, mockSerializationWriterFactory.Object);
+            serializationFactoryRegistry.ContentTypeAssociatedFactories.TryAdd(StreamContentType, mockSerializationWriterFactory.Object);
         
             Assert.IsNotType<BackingStoreSerializationWriterProxyFactory>(serializationFactoryRegistry.ContentTypeAssociatedFactories[StreamContentType]);
         
@@ -32,7 +32,7 @@ namespace Microsoft.Kiota.Abstractions.Tests
             // Arrange
             var parseNodeRegistry = new ParseNodeFactoryRegistry();
             var mockParseNodeFactory = new Mock<IParseNodeFactory>();
-            parseNodeRegistry.ContentTypeAssociatedFactories.Add(StreamContentType, mockParseNodeFactory.Object);
+            parseNodeRegistry.ContentTypeAssociatedFactories.TryAdd(StreamContentType, mockParseNodeFactory.Object);
         
             Assert.IsNotType<BackingStoreParseNodeFactory>(parseNodeRegistry.ContentTypeAssociatedFactories[StreamContentType]);
         

--- a/Microsoft.Kiota.Abstractions.Tests/Serialization/ParseNodeFactoryRegistryTests.cs
+++ b/Microsoft.Kiota.Abstractions.Tests/Serialization/ParseNodeFactoryRegistryTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Kiota.Abstractions.Tests.Serialization
             var mockParseNodeFactory = new Mock<IParseNodeFactory>();
             var mockParseNode = new Mock<IParseNode>();
             mockParseNodeFactory.Setup(parseNodeFactory => parseNodeFactory.GetRootParseNode(streamContentType, It.IsAny<Stream>())).Returns(mockParseNode.Object);
-            _parseNodeFactoryRegistry.ContentTypeAssociatedFactories.Add(streamContentType, mockParseNodeFactory.Object);
+            _parseNodeFactoryRegistry.ContentTypeAssociatedFactories.TryAdd(streamContentType, mockParseNodeFactory.Object);
             // Act
             var rootParseNode = _parseNodeFactoryRegistry.GetRootParseNode(streamContentType, testStream);
             // Assert
@@ -48,7 +48,7 @@ namespace Microsoft.Kiota.Abstractions.Tests.Serialization
             var mockParseNodeFactory = new Mock<IParseNodeFactory>();
             var mockParseNode = new Mock<IParseNode>();
             mockParseNodeFactory.Setup(parseNodeFactory => parseNodeFactory.GetRootParseNode(applicationJsonContentType, It.IsAny<Stream>())).Returns(mockParseNode.Object);
-            _parseNodeFactoryRegistry.ContentTypeAssociatedFactories.Add(applicationJsonContentType, mockParseNodeFactory.Object);
+            _parseNodeFactoryRegistry.ContentTypeAssociatedFactories.TryAdd(applicationJsonContentType, mockParseNodeFactory.Object);
             // Act
             var rootParseNode = _parseNodeFactoryRegistry.GetRootParseNode("application/vnd+json", testStream);
             // Assert

--- a/Microsoft.Kiota.Abstractions.Tests/Serialization/SerializationWriterFactoryRegistryTests.cs
+++ b/Microsoft.Kiota.Abstractions.Tests/Serialization/SerializationWriterFactoryRegistryTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Kiota.Abstractions.Tests.Serialization
             var mockSerializationWriterFactory = new Mock<ISerializationWriterFactory>();
             var mockSerializationWriter = new Mock<ISerializationWriter>();
             mockSerializationWriterFactory.Setup(serializationWriterFactory => serializationWriterFactory.GetSerializationWriter(streamContentType)).Returns(mockSerializationWriter.Object);
-            _serializationWriterFactoryRegistry.ContentTypeAssociatedFactories.Add(streamContentType, mockSerializationWriterFactory.Object);
+            _serializationWriterFactoryRegistry.ContentTypeAssociatedFactories.TryAdd(streamContentType, mockSerializationWriterFactory.Object);
             // Act
             var serializationWriter = _serializationWriterFactoryRegistry.GetSerializationWriter(streamContentType);
             // Assert
@@ -46,7 +46,7 @@ namespace Microsoft.Kiota.Abstractions.Tests.Serialization
             var mockSerializationWriterFactory = new Mock<ISerializationWriterFactory>();
             var mockSerializationWriter = new Mock<ISerializationWriter>();
             mockSerializationWriterFactory.Setup(serializationWriterFactory => serializationWriterFactory.GetSerializationWriter(applicationJsonContentType)).Returns(mockSerializationWriter.Object);
-            _serializationWriterFactoryRegistry.ContentTypeAssociatedFactories.Add(applicationJsonContentType, mockSerializationWriterFactory.Object);
+            _serializationWriterFactoryRegistry.ContentTypeAssociatedFactories.TryAdd(applicationJsonContentType, mockSerializationWriterFactory.Object);
             // Act
             var serializationWriter = _serializationWriterFactoryRegistry.GetSerializationWriter("application/vnd+json");
             // Assert

--- a/src/ApiClientBuilder.cs
+++ b/src/ApiClientBuilder.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Linq;
-using Microsoft.Kiota.Abstractions.Extensions;
 using Microsoft.Kiota.Abstractions.Serialization;
 using Microsoft.Kiota.Abstractions.Store;
 
@@ -46,10 +45,14 @@ namespace Microsoft.Kiota.Abstractions
         {
             ISerializationWriterFactory result = original ?? throw new ArgumentNullException(nameof(original));
             if(original is SerializationWriterFactoryRegistry registry)
+            {
                 EnableBackingStoreForSerializationRegistry(registry);
+                if(registry != SerializationWriterFactoryRegistry.DefaultInstance)// if the registry is the default instance, we already enabled it above. No need to do it twice
+                    EnableBackingStoreForSerializationRegistry(SerializationWriterFactoryRegistry.DefaultInstance);
+            }
             else
                 result = new BackingStoreSerializationWriterProxyFactory(original);
-            EnableBackingStoreForSerializationRegistry(SerializationWriterFactoryRegistry.DefaultInstance);
+
             return result;
         }
         /// <summary>
@@ -61,10 +64,14 @@ namespace Microsoft.Kiota.Abstractions
         {
             IParseNodeFactory result = original ?? throw new ArgumentNullException(nameof(original));
             if(original is ParseNodeFactoryRegistry registry)
+            {
                 EnableBackingStoreForParseNodeRegistry(registry);
+                if(registry != ParseNodeFactoryRegistry.DefaultInstance)// if the registry is the default instance, we already enabled it above. No need to do it twice
+                    EnableBackingStoreForParseNodeRegistry(ParseNodeFactoryRegistry.DefaultInstance);
+            }
             else
                 result = new BackingStoreParseNodeFactory(original);
-            EnableBackingStoreForParseNodeRegistry(ParseNodeFactoryRegistry.DefaultInstance);
+            
             return result;
         }
         private static void EnableBackingStoreForParseNodeRegistry(ParseNodeFactoryRegistry registry)

--- a/src/Microsoft.Kiota.Abstractions.csproj
+++ b/src/Microsoft.Kiota.Abstractions.csproj
@@ -14,7 +14,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>rc.4</VersionSuffix>
+    <VersionSuffix>rc.5</VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <SignAssembly>false</SignAssembly>
     <DelaySign>false</DelaySign>

--- a/src/serialization/ParseNodeFactoryRegistry.cs
+++ b/src/serialization/ParseNodeFactoryRegistry.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Kiota.Abstractions.Serialization
         /// <summary>
         /// List of factories that are registered by content type.
         /// </summary>
-        public ConcurrentDictionary<string, IParseNodeFactory> ContentTypeAssociatedFactories { get; set; } = new ConcurrentDictionary<string, IParseNodeFactory>();
+        public ConcurrentDictionary<string, IParseNodeFactory> ContentTypeAssociatedFactories { get; set; } = new();
         internal static readonly Regex contentTypeVendorCleanupRegex = new(@"[^/]+\+", RegexOptions.Compiled);
         /// <summary>
         /// Get the <see cref="IParseNode"/> instance that is the root of the content

--- a/src/serialization/ParseNodeFactoryRegistry.cs
+++ b/src/serialization/ParseNodeFactoryRegistry.cs
@@ -3,7 +3,7 @@
 // ------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -32,7 +32,7 @@ namespace Microsoft.Kiota.Abstractions.Serialization
         /// <summary>
         /// List of factories that are registered by content type.
         /// </summary>
-        public Dictionary<string, IParseNodeFactory> ContentTypeAssociatedFactories { get; set; } = new Dictionary<string, IParseNodeFactory>();
+        public ConcurrentDictionary<string, IParseNodeFactory> ContentTypeAssociatedFactories { get; set; } = new ConcurrentDictionary<string, IParseNodeFactory>();
         internal static readonly Regex contentTypeVendorCleanupRegex = new(@"[^/]+\+", RegexOptions.Compiled);
         /// <summary>
         /// Get the <see cref="IParseNode"/> instance that is the root of the content

--- a/src/serialization/SerializationWriterFactoryRegistry.cs
+++ b/src/serialization/SerializationWriterFactoryRegistry.cs
@@ -3,7 +3,7 @@
 // ------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Linq;
 
 namespace Microsoft.Kiota.Abstractions.Serialization
@@ -30,7 +30,7 @@ namespace Microsoft.Kiota.Abstractions.Serialization
         /// <summary>
         /// List of factories that are registered by content type.
         /// </summary>
-        public Dictionary<string, ISerializationWriterFactory> ContentTypeAssociatedFactories { get; set; } = new Dictionary<string, ISerializationWriterFactory>();
+        public ConcurrentDictionary<string, ISerializationWriterFactory> ContentTypeAssociatedFactories { get; set; } = new();
         /// <summary>
         /// Get the relevant <see cref="ISerializationWriter"/> instance for the given content type
         /// </summary>


### PR DESCRIPTION
This PR closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1629

It changes the `ParseNodeFactoryRegistry` and `SerializationWriterFactoryRegistry` to hold the factories to alleviate race conditions reported when the collection is modified during the enabling of the backing store. 