### PR TITLE
Fixes for nested IBackedModel properties in the InMemoryBackingStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [1.1.2] - 2023-05-17
+
+### Changed
+
+- Fixes a bug in the InMemoryBackingStore that would not leave out properties in nested IBackedModel properties.
+
 ## [1.1.1] - 2023-04-06
 
 ### Added

--- a/src/Microsoft.Kiota.Abstractions.csproj
+++ b/src/Microsoft.Kiota.Abstractions.csproj
@@ -13,7 +13,7 @@
     <PackageProjectUrl>https://microsoft.github.io/kiota/</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.1.1</VersionPrefix>
+    <VersionPrefix>1.1.2</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <SignAssembly>false</SignAssembly>


### PR DESCRIPTION
In the event that a property in an `IBackedModel` is also an `IBackedModel` or a collection of `IBackedModel`, a change in one of the properties is currently propagated up. However, the nested model only returns its changed properties which would create the issue where the payload generated creates the notion that the nested property has properties removed.

This PR, ensure the whole property is marked as "dirty" to prevent unwanted side effects when performing PATCH calls in nested property.
 
Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1904
Querying the list of attendees, then adding to the nested list, should return all the items so that the update reflects that the property has a new value added.
Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1817
Querying the list of attendees from the parent RequiredResourceAccess object, then adding to the nested list, should return all the items so that the update reflects that the property has a new value added.
Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1888
Querying the list of OAuth2PermissionScope from the parent event Application, then adding to the nested list, should return all the items so that the update reflects that the property has a new value added.
