### PR TITLE
Fix race conditions in backing store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [1.1.4] - 2023-06-22
+
+### Fixed
+
+- Use concurrent dictionary for In memory backing store registry to avoid race conditions.
+
 ## [1.1.3] - 2023-06-13
 
 ### Fixed

--- a/Microsoft.Kiota.Abstractions.Tests/Store/InMemoryBackingStoreTests.cs
+++ b/Microsoft.Kiota.Abstractions.Tests/Store/InMemoryBackingStoreTests.cs
@@ -97,12 +97,11 @@ namespace Microsoft.Kiota.Abstractions.Tests.Store
             testUser.AdditionalData.Add("anotherExtension", null);
             // Assert by retrieving only changed values
             testUser.BackingStore.ReturnOnlyChangedValues = true;
-            var changedValues = testUser.BackingStore.Enumerate();
+            var changedValues = testUser.BackingStore.Enumerate().ToDictionary(x => x.Key, y => y.Value);
             Assert.NotEmpty(changedValues);
             Assert.Equal(2, changedValues.Count());
-            var resultList = changedValues.ToList();
-            Assert.Equal("additionalData", resultList[0].Key);
-            Assert.Equal("businessPhones", resultList[1].Key);
+            Assert.True(changedValues.ContainsKey("businessPhones"));
+            Assert.True(changedValues.ContainsKey("additionalData"));
         }
         [Fact]
         public void TestsBackingStoreEmbeddedInModelWithCollectionPropertyReplacedWithNewCollection()

--- a/src/Microsoft.Kiota.Abstractions.csproj
+++ b/src/Microsoft.Kiota.Abstractions.csproj
@@ -14,7 +14,7 @@
     <PackageProjectUrl>https://microsoft.github.io/kiota/</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.1.3</VersionPrefix>
+    <VersionPrefix>1.1.4</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <SignAssembly>false</SignAssembly>

--- a/src/store/InMemoryBackingStore.cs
+++ b/src/store/InMemoryBackingStore.cs
@@ -129,7 +129,8 @@ namespace Microsoft.Kiota.Abstractions.Store
         }
 
         /// <summary>
-        /// Adds a callback to subscribe to events in the store with the given subscription id
+        /// Adds a callback to subscribe to events in the store with the given subscription id. 
+        /// If a subscription exists with the same subscriptionId, the callback is updated/replaced
         /// </summary>
         /// <param name="callback">The callback to add</param>
         /// <param name="subscriptionId">The subscription id to use for subscription</param>
@@ -139,7 +140,7 @@ namespace Microsoft.Kiota.Abstractions.Store
                 throw new ArgumentNullException(nameof(subscriptionId));
             if(callback == null)
                 throw new ArgumentNullException(nameof(callback));
-            subscriptions.TryAdd(subscriptionId, callback);
+            subscriptions.AddOrUpdate(subscriptionId, callback, (_,_) => callback);
         }
 
         /// <summary>

--- a/src/store/InMemoryBackingStore.cs
+++ b/src/store/InMemoryBackingStore.cs
@@ -4,9 +4,9 @@
 
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Kiota.Abstractions.Extensions;
 
 namespace Microsoft.Kiota.Abstractions.Store
 {
@@ -20,8 +20,8 @@ namespace Microsoft.Kiota.Abstractions.Store
         /// Determines whether the backing store should only return changed values when queried.
         /// </summary>
         public bool ReturnOnlyChangedValues { get; set; }
-        private readonly Dictionary<string, Tuple<bool, object?>> store = new();
-        private readonly Dictionary<string, Action<string, object?, object?>> subscriptions = new();
+        private readonly ConcurrentDictionary<string, Tuple<bool, object?>> store = new();
+        private readonly ConcurrentDictionary<string, Action<string, object?, object?>> subscriptions = new();
 
         /// <summary>
         /// Gets the specified object with the given key from the store.
@@ -139,7 +139,7 @@ namespace Microsoft.Kiota.Abstractions.Store
                 throw new ArgumentNullException(nameof(subscriptionId));
             if(callback == null)
                 throw new ArgumentNullException(nameof(callback));
-            subscriptions.Add(subscriptionId, callback);
+            subscriptions.TryAdd(subscriptionId, callback);
         }
 
         /// <summary>
@@ -148,7 +148,7 @@ namespace Microsoft.Kiota.Abstractions.Store
         /// <param name="subscriptionId">The id of the subscription to de-register </param>
         public void Unsubscribe(string subscriptionId)
         {
-            subscriptions.Remove(subscriptionId);
+            subscriptions.TryRemove(subscriptionId, out _);
         }
         /// <summary>
         /// Clears the store


### PR DESCRIPTION
Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1980

Changes store dictionaries to `ConcurrentDictionary` instance to alleviate race conditions from possible concurrent writes/accesses. 