### PR TITLE
Issue #81: Fix case insensitivity bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+## [1.2.1] - 2023-07-03
+
+### Fixed
+
+- Fixed a bug that caused the uri parameters not to be applied when the Uri template had a different casing than the parameter name that was used to set it.
 
 ## [1.2.0] - 2023-06-28
 

--- a/Microsoft.Kiota.Abstractions.Tests/RequestInformationTests.cs
+++ b/Microsoft.Kiota.Abstractions.Tests/RequestInformationTests.cs
@@ -312,6 +312,22 @@ namespace Microsoft.Kiota.Abstractions.Tests
             serializationWriterMock.Verify(x => x.WriteStringValue(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
             serializationWriterMock.Verify(x => x.WriteCollectionOfPrimitiveValues(It.IsAny<string>(), It.IsAny<IEnumerable<string>>()), Times.Once);
         }
+        [Fact]
+        public void GetUriResolvesParametersCaseInsensitive()
+        {
+            // Arrange
+            var testRequest = new RequestInformation()
+            {
+                HttpMethod = Method.GET,
+                UrlTemplate = "http://localhost/{URITemplate}/ParameterMapping?IsCaseSensitive={IsCaseSensitive}"
+            };
+            // Act
+            testRequest.PathParameters.Add("UriTemplate", "UriTemplate");
+            testRequest.QueryParameters.Add("iscasesensitive", "false");
+
+            // Assert
+            Assert.Equal("http://localhost/UriTemplate/ParameterMapping?IsCaseSensitive=false", testRequest.URI.ToString());
+        }
     }
 
     /// <summary>The messages in a mailbox or folder. Read-only. Nullable.</summary>

--- a/src/Microsoft.Kiota.Abstractions.csproj
+++ b/src/Microsoft.Kiota.Abstractions.csproj
@@ -14,7 +14,7 @@
     <PackageProjectUrl>https://aka.ms/kiota/docs</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.2.0</VersionPrefix>
+    <VersionPrefix>1.2.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <SignAssembly>false</SignAssembly>

--- a/src/RequestInformation.cs
+++ b/src/RequestInformation.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Kiota.Abstractions
                     if(UrlTemplate?.IndexOf("{+baseurl}", StringComparison.OrdinalIgnoreCase) >= 0 && !PathParameters.ContainsKey("baseurl"))
                         throw new InvalidOperationException($"{nameof(PathParameters)} must contain a value for \"baseurl\" for the url to be built.");
 
-                    var parsedUrlTemplate = new UriTemplate(UrlTemplate);
+                    var parsedUrlTemplate = new UriTemplate(UrlTemplate, caseInsensitiveParameterNames: true);
                     foreach(var urlTemplateParameter in PathParameters)
                     {
                         parsedUrlTemplate.SetParameter(urlTemplateParameter.Key, GetSanitizedValue(urlTemplateParameter.Value));


### PR DESCRIPTION
In [Issue #81](https://github.com/microsoft/kiota-abstractions-dotnet/issues/81) @seruminar described why URIs don't contain query parameters when the models they are derived from have pascal cased property names.

Here is my short take on the problem:
    - When the URL template contains query parameters with upper case first letters and the QueryParameters contains them in lowerCase (because they are added using x.Name.ToFirstCharacterLowerCase()) then the names are not matched and the resulting URI does not contain the parameters.
    - When in the URI getter the parameters are actually set using uriTemplate.SetParameter then in the dictionary the casing does not match, and therefore they are silently failing to be set.
    - The UriTemplate ctor contains the optional setting (caseInsensitiveParameterNames) to use a case insensitive dictionary. IMHO this is the best solution because then it does not matter what kind of casing patterns the API models have.

The alternative solution to this would be to change AddQueryParameters where
`x.Name.ToFirstCharacterLowerCase()` is called for each parameter. Lowercasing the first char is what causes this bug in the first place. The strings in the dictionary would naturally match the API model from which they are collected. 
What do you think would be the better fix?

Here a little demo of the problem:
Before:
![grafik](https://github.com/microsoft/kiota-abstractions-dotnet/assets/4134414/d905368b-3a6b-4be3-8e07-a4a7161badd1)
After:
![grafik](https://github.com/microsoft/kiota-abstractions-dotnet/assets/4134414/3dbc4049-46c6-4348-9d4b-4d1e81669adf)


