### PR TITLE
Fix for duplicate subscription creation in InMemoryBackingStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1] - 2023-08-08
+
+### Fixed
+
+- Fixed a bug where excess duplicate subscriptions would be created on the same property in the backing store causing performance issues in some scenarios. Related to https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1994
+
 ## [1.3.0] - 2023-08-01
 
 ### Added

--- a/src/Microsoft.Kiota.Abstractions.csproj
+++ b/src/Microsoft.Kiota.Abstractions.csproj
@@ -14,7 +14,7 @@
     <PackageProjectUrl>https://aka.ms/kiota/docs</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.3.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <SignAssembly>false</SignAssembly>

--- a/src/store/InMemoryBackingStore.cs
+++ b/src/store/InMemoryBackingStore.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Kiota.Abstractions.Store
                 {
                     backedModel.BackingStore.InitializationCompleted = false;// All its properties are dirty as the model has been touched.
                     Set(key, value);
-                });
+                },key); // use property name(key) as subscriptionId to prevent excess subscription creation in the event this is called again
             }
             // if its an IBackedModel collection property to the store, subscribe to item properties' BackingStores and use the events to flag the collection property is "dirty"
             if(value is ICollection collectionValues)
@@ -86,7 +86,7 @@ namespace Microsoft.Kiota.Abstractions.Store
                     model.BackingStore.Subscribe((keyString, oldObject, newObject) =>
                     {
                         Set(key, value);
-                    });
+                    },key);// use property name(key) as subscriptionId to prevent excess subscription creation in the event this is called again
                 });
             }
 


### PR DESCRIPTION
This PR closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1994. 

It fixes a bug where multiple duplicate subscriptions would be added to collection properties when subscribing to changes in the collection. This PR updates the subscription to use the property name as unique key to avoid duplicate subscriptions being added and therefore having the side effect of each having to be invoked on a change causing the delayed execution observed in https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1994. 

Tests have also been updated to capture the scenario. 