### PR TITLE
GetCollectionOf* methods of IParseNode can now return null

### DIFF
--- a/src/serialization/IParseNode.cs
+++ b/src/serialization/IParseNode.cs
@@ -95,22 +95,22 @@ namespace Microsoft.Kiota.Abstractions.Serialization
         /// Gets the collection of primitive values of the node.
         /// </summary>
         /// <returns>The collection of primitive values.</returns>
-        IEnumerable<T> GetCollectionOfPrimitiveValues<T>();
+        IEnumerable<T>? GetCollectionOfPrimitiveValues<T>();
         /// <summary>
         /// Gets the collection of enum values of the node.
         /// </summary>
         /// <returns>The collection of enum values.</returns>
 #if NET5_0_OR_GREATER
-        IEnumerable<T?> GetCollectionOfEnumValues<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]T>() where T : struct, Enum;
+        IEnumerable<T?>? GetCollectionOfEnumValues<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]T>() where T : struct, Enum;
 #else
-        IEnumerable<T?> GetCollectionOfEnumValues<T>() where T : struct, Enum;
+        IEnumerable<T?>? GetCollectionOfEnumValues<T>() where T : struct, Enum;
 #endif
         /// <summary>
         /// Gets the collection of model objects values of the node.
         /// </summary>
         /// <param name="factory">The factory to use to create the model object.</param>
         /// <returns>The collection of model objects values.</returns>
-        IEnumerable<T> GetCollectionOfObjectValues<T>(ParsableFactory<T> factory) where T : IParsable;
+        IEnumerable<T>? GetCollectionOfObjectValues<T>(ParsableFactory<T> factory) where T : IParsable;
         /// <summary>
         /// Gets the enum value of the node.
         /// </summary>

--- a/src/serialization/KiotaJsonSerializer.Deserialization.cs
+++ b/src/serialization/KiotaJsonSerializer.Deserialization.cs
@@ -55,23 +55,23 @@ public static partial class KiotaJsonSerializer
     /// </summary>
     /// <param name="stream">The stream to deserialize.</param>
     /// <param name="parsableFactory">The factory to create the object.</param>
-    public static IEnumerable<T> DeserializeCollection<T>(Stream stream, ParsableFactory<T> parsableFactory) where T : IParsable
+    public static IEnumerable<T>? DeserializeCollection<T>(Stream stream, ParsableFactory<T> parsableFactory) where T : IParsable
     => KiotaSerializer.DeserializeCollection(_jsonContentType, stream, parsableFactory);
     /// <summary>
     /// Deserializes the given stream into a collection of objects based on the content type.
     /// </summary>
     /// <param name="serializedRepresentation">The serialized representation of the objects.</param>
     /// <param name="parsableFactory">The factory to create the object.</param>
-    public static IEnumerable<T> DeserializeCollection<T>(string serializedRepresentation, ParsableFactory<T> parsableFactory) where T : IParsable
+    public static IEnumerable<T>? DeserializeCollection<T>(string serializedRepresentation, ParsableFactory<T> parsableFactory) where T : IParsable
     => KiotaSerializer.DeserializeCollection(_jsonContentType, serializedRepresentation, parsableFactory);
     /// <summary>
     /// Deserializes the given stream into a collection of objects based on the content type.
     /// </summary>
     /// <param name="stream">The stream to deserialize.</param>
 #if NET5_0_OR_GREATER
-    public static IEnumerable<T> DeserializeCollection<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(Stream stream) where T : IParsable
+    public static IEnumerable<T>? DeserializeCollection<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(Stream stream) where T : IParsable
 #else
-    public static IEnumerable<T> DeserializeCollection<T>(Stream stream) where T : IParsable
+    public static IEnumerable<T>? DeserializeCollection<T>(Stream stream) where T : IParsable
 #endif
     => KiotaSerializer.DeserializeCollection<T>(_jsonContentType, stream);
     /// <summary>
@@ -79,9 +79,9 @@ public static partial class KiotaJsonSerializer
     /// </summary>
     /// <param name="serializedRepresentation">The serialized representation of the object.</param>
 #if NET5_0_OR_GREATER
-    public static IEnumerable<T> DeserializeCollection<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(string serializedRepresentation) where T : IParsable
+    public static IEnumerable<T>? DeserializeCollection<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(string serializedRepresentation) where T : IParsable
 #else
-    public static IEnumerable<T> DeserializeCollection<T>(string serializedRepresentation) where T : IParsable
+    public static IEnumerable<T>? DeserializeCollection<T>(string serializedRepresentation) where T : IParsable
 #endif
     => KiotaSerializer.DeserializeCollection<T>(_jsonContentType, serializedRepresentation);
 }

--- a/src/serialization/KiotaSerializer.Deserialization.cs
+++ b/src/serialization/KiotaSerializer.Deserialization.cs
@@ -90,7 +90,7 @@ public static partial class KiotaSerializer
     /// <param name="contentType">The content type of the stream.</param>
     /// <param name="stream">The stream to deserialize.</param>
     /// <param name="parsableFactory">The factory to create the object.</param>
-    public static IEnumerable<T> DeserializeCollection<T>(string contentType, Stream stream, ParsableFactory<T> parsableFactory) where T : IParsable
+    public static IEnumerable<T>? DeserializeCollection<T>(string contentType, Stream stream, ParsableFactory<T> parsableFactory) where T : IParsable
     {
         if(string.IsNullOrEmpty(contentType)) throw new ArgumentNullException(nameof(contentType));
         if(stream == null) throw new ArgumentNullException(nameof(stream));
@@ -104,7 +104,7 @@ public static partial class KiotaSerializer
     /// <param name="contentType">The content type of the stream.</param>
     /// <param name="serializedRepresentation">The serialized representation of the objects.</param>
     /// <param name="parsableFactory">The factory to create the object.</param>
-    public static IEnumerable<T> DeserializeCollection<T>(string contentType, string serializedRepresentation, ParsableFactory<T> parsableFactory) where T : IParsable
+    public static IEnumerable<T>? DeserializeCollection<T>(string contentType, string serializedRepresentation, ParsableFactory<T> parsableFactory) where T : IParsable
     {
         if(string.IsNullOrEmpty(serializedRepresentation)) throw new ArgumentNullException(nameof(serializedRepresentation));
         using var stream = GetStreamFromString(serializedRepresentation);
@@ -116,9 +116,9 @@ public static partial class KiotaSerializer
     /// <param name="contentType">The content type of the stream.</param>
     /// <param name="stream">The stream to deserialize.</param>
 #if NET5_0_OR_GREATER
-    public static IEnumerable<T> DeserializeCollection<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(string contentType, Stream stream) where T : IParsable
+    public static IEnumerable<T>? DeserializeCollection<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(string contentType, Stream stream) where T : IParsable
 #else
-    public static IEnumerable<T> DeserializeCollection<T>(string contentType, Stream stream) where T : IParsable
+    public static IEnumerable<T>? DeserializeCollection<T>(string contentType, Stream stream) where T : IParsable
 #endif
     => DeserializeCollection(contentType, stream, GetFactoryFromType<T>());
     /// <summary>
@@ -127,9 +127,9 @@ public static partial class KiotaSerializer
     /// <param name="contentType">The content type of the stream.</param>
     /// <param name="serializedRepresentation">The serialized representation of the object.</param>
 #if NET5_0_OR_GREATER
-    public static IEnumerable<T> DeserializeCollection<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(string contentType, string serializedRepresentation) where T : IParsable
+    public static IEnumerable<T>? DeserializeCollection<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(string contentType, string serializedRepresentation) where T : IParsable
 #else
-    public static IEnumerable<T> DeserializeCollection<T>(string contentType, string serializedRepresentation) where T : IParsable
+    public static IEnumerable<T>? DeserializeCollection<T>(string contentType, string serializedRepresentation) where T : IParsable
 #endif
     => DeserializeCollection(contentType, serializedRepresentation, GetFactoryFromType<T>());
 }


### PR DESCRIPTION
Made the return type of `GetCollectionOfPrimitiveValues`, `GetCollectionOfEnumValues` and `GetCollectionOfObjectValues` in `IParseNode` nullable  to allow for null when the underlying type is not an collection type.

This change is part of the solution for the problem discussed here microsoft/kiota#3976.