### PR TITLE
Add missing DynamicallyAccessedMembers annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.9] - 2024-02-05
+
+### Changed
+
+- Added `DynamicallyAccessedMembers` annotation to `RequestInformation.Configure`.
+
 ## [1.7.8] - 2024-02-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Added `DynamicallyAccessedMembers` annotation to `RequestInformation.Configure`.
+- Fixes `IsTrimmable` property on the project.
 
 ## [1.7.8] - 2024-02-02
 

--- a/src/Microsoft.Kiota.Abstractions.csproj
+++ b/src/Microsoft.Kiota.Abstractions.csproj
@@ -34,7 +34,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <NoWarn>$(NoWarn);NU5048;NETSDK1138</NoWarn>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFrameworkVersion)' == 'net5.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0'">
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 

--- a/src/Microsoft.Kiota.Abstractions.csproj
+++ b/src/Microsoft.Kiota.Abstractions.csproj
@@ -14,7 +14,7 @@
     <PackageProjectUrl>https://aka.ms/kiota/docs</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.7.8</VersionPrefix>
+    <VersionPrefix>1.7.9</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <SignAssembly>false</SignAssembly>

--- a/src/RequestInformation.cs
+++ b/src/RequestInformation.cs
@@ -47,7 +47,11 @@ namespace Microsoft.Kiota.Abstractions
         /// </summary>
         /// <typeparam name="T">Type for the query parameters</typeparam>
         /// <param name="requestConfiguration">Callback to configure the request</param>
+#if NET5_0_OR_GREATER
+        public void Configure<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(Action<RequestConfiguration<T>>? requestConfiguration) where T : class, new()
+#else
         public void Configure<T>(Action<RequestConfiguration<T>>? requestConfiguration) where T : class, new()
+#endif
         {
             if(requestConfiguration == null) return;
             var requestConfig = new RequestConfiguration<T>();


### PR DESCRIPTION
This adds a missing `DynamicallyAccessedMembers` on Configure that means that the `DynamicallyAccessedMembers` annotation on `AddQueryParameters` is not fulfilled.

This PR does not have an associated open issue, but is related to https://github.com/microsoft/kiota/issues/4065

Example warning using Microsoft.Kiota.Abstractions 1.7.8
```
ILC : Trim analysis warning IL2091: Microsoft.Kiota.Abstractions.RequestInformation.Configure<T>(Action`1<RequestConfig
uration`1<!!0>>): 'T' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties' in 'Microsoft
.Kiota.Abstractions.RequestInformation.AddQueryParameters<T>(!!0)'. The generic parameter 'T' of 'Microsoft.Kiota.Abstr
actions.RequestInformation.Configure<T>(Action`1<RequestConfiguration`1<!!0>>)' does not have matching annotations. The
 source value must declare at least the same requirements as those declared on the target location it is assigned to.
```

This also fixes an issue that prevented `IsTrimmable` being set in the csproj.

Fixes #188