### PR TITLE
Implement MultipartBody filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `MultipartBody` now supports an optional `fileName` parameter to specify the file name of the part. (https://github.com/microsoft/kiota-abstractions-dotnet/issues/212)
+
 ## [1.8.0] - 2024-03-18
 
 ### Added

--- a/Microsoft.Kiota.Abstractions.Tests/MultipartBodyTests.cs
+++ b/Microsoft.Kiota.Abstractions.Tests/MultipartBodyTests.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.Kiota.Abstractions.Serialization;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Kiota.Abstractions.Tests;
+
+public class MultipartBodyTests
+{
+    [Fact]
+    public void KeepsFilename()
+    {
+        var writerMock = new Mock<ISerializationWriter>();
+        var requestAdapterMock = new Mock<IRequestAdapter>();
+        var serializationFactoryMock = new Mock<ISerializationWriterFactory>();
+
+        var body = new MultipartBody();
+
+        requestAdapterMock
+            .Setup(r => r.SerializationWriterFactory)
+            .Returns(serializationFactoryMock.Object);
+
+        body.RequestAdapter = requestAdapterMock.Object;
+
+        writerMock.Setup(w => w.WriteStringValue("", "--" + body.Boundary));
+        writerMock.Setup(w => w.WriteStringValue("Content-Type", "application/json"));
+        writerMock.Setup(w => w.WriteStringValue("Content-Disposition", "form-data; name=\"file\"; filename=\"file.json\""));
+        writerMock.Setup(w => w.WriteStringValue("", "fileContent"));
+        writerMock.Setup(w => w.WriteStringValue("", ""));
+        writerMock.Setup(w => w.WriteStringValue("", "--" + body.Boundary + "--"));
+
+        body.AddOrReplacePart("file", "application/json", "fileContent", "file.json");
+        body.Serialize(writerMock.Object);
+
+        writerMock.VerifyAll();
+        requestAdapterMock.VerifyAll();
+        serializationFactoryMock.VerifyAll();
+    }
+
+    [Fact]
+    public void WorksWithoutFilename()
+    {
+        var writerMock = new Mock<ISerializationWriter>();
+        var requestAdapterMock = new Mock<IRequestAdapter>();
+        var serializationFactoryMock = new Mock<ISerializationWriterFactory>();
+
+        var body = new MultipartBody();
+
+        requestAdapterMock
+            .Setup(r => r.SerializationWriterFactory)
+            .Returns(serializationFactoryMock.Object);
+
+        body.RequestAdapter = requestAdapterMock.Object;
+
+        writerMock.Setup(w => w.WriteStringValue("", "--" + body.Boundary));
+        writerMock.Setup(w => w.WriteStringValue("Content-Type", "application/json"));
+        writerMock.Setup(w => w.WriteStringValue("Content-Disposition", "form-data; name=\"file\""));
+        writerMock.Setup(w => w.WriteStringValue("", "fileContent"));
+        writerMock.Setup(w => w.WriteStringValue("", ""));
+        writerMock.Setup(w => w.WriteStringValue("", "--" + body.Boundary + "--"));
+
+        body.AddOrReplacePart("file", "application/json", "fileContent");
+        body.Serialize(writerMock.Object);
+
+        writerMock.VerifyAll();
+        requestAdapterMock.VerifyAll();
+        serializationFactoryMock.VerifyAll();
+    }
+}

--- a/src/Microsoft.Kiota.Abstractions.csproj
+++ b/src/Microsoft.Kiota.Abstractions.csproj
@@ -14,7 +14,7 @@
     <PackageProjectUrl>https://aka.ms/kiota/docs</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.8.0</VersionPrefix>
+    <VersionPrefix>1.8.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <SignAssembly>false</SignAssembly>

--- a/src/MultipartBody.cs
+++ b/src/MultipartBody.cs
@@ -178,7 +178,7 @@ public class MultipartBody : IParsable
             }
             catch(InvalidOperationException) when(part?.Content is byte[] currentBinary)
             { // binary payload
-                writer.WriteByteArrayValue(pair.Key, currentBinary);
+                writer.WriteByteArrayValue(part.Name, currentBinary);
             }
         }
         AddNewLine(writer);

--- a/src/MultipartBody.cs
+++ b/src/MultipartBody.cs
@@ -109,12 +109,8 @@ public class MultipartBody : IParsable
         }
         var first = true;
         var contentDispositionBuilder = new StringBuilder();
-        foreach(var pair in _parts)
+        foreach(var part in _parts.Values)
         {
-            var part = pair.Value;
-            if (part == null)
-                throw new InvalidOperationException($"Part {pair.Key} was null");
-
             try
             {
                 if(first)
@@ -173,7 +169,7 @@ public class MultipartBody : IParsable
                 }
                 else
                 {
-                    throw new InvalidOperationException($"Unsupported type {part.Content.GetType().Name} for part {pair.Key}");
+                    throw new InvalidOperationException($"Unsupported type {part.Content.GetType().Name} for part {part.Name}");
                 }
             }
             catch(InvalidOperationException) when(part?.Content is byte[] currentBinary)


### PR DESCRIPTION
Fixes #212.

This adds a class to hold information about a part added to a `MultipartBody`. In addition to that, it is now possible to pass a file name to the `AddOrReplacePart` method, that will be added to the `Content-Disposition` header when serializing.