### PR TITLE
fix time formatting for other cultures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.9.1] - 2024-05-24
+## [1.9.3] - 2024-05-28
+
+### Changed
+
+- Fix time formatting for other cultures.
+
+## [1.9.2] - 2024-05-24
 
 ### Changed
 

--- a/Microsoft.Kiota.Abstractions.Tests/RequestInformationTests.cs
+++ b/Microsoft.Kiota.Abstractions.Tests/RequestInformationTests.cs
@@ -271,11 +271,9 @@ namespace Microsoft.Kiota.Abstractions.Tests
             };
 
             var currentCulture = CultureInfo.CurrentCulture;
-            var currentUICulture = CultureInfo.CurrentUICulture;
 
             // Act
             Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("da-DK");
-            Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo("da-DK");
             var time = new Time(6, 0, 0);
             var pathParameters = new Dictionary<string, object>
             {
@@ -289,7 +287,6 @@ namespace Microsoft.Kiota.Abstractions.Tests
 
             // Cleanup
             Thread.CurrentThread.CurrentCulture = currentCulture;
-            Thread.CurrentThread.CurrentUICulture = currentUICulture;
         }
         [Fact]
         public void ThrowsInvalidOperationExceptionWhenBaseUrlNotSet()

--- a/Microsoft.Kiota.Abstractions.Tests/RequestInformationTests.cs
+++ b/Microsoft.Kiota.Abstractions.Tests/RequestInformationTests.cs
@@ -1,6 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using System.Threading;
 using Microsoft.Kiota.Abstractions.Serialization;
 using Microsoft.Kiota.Abstractions.Tests.Mocks;
 using Moq;
@@ -257,6 +259,37 @@ namespace Microsoft.Kiota.Abstractions.Tests
 
             // Assert
             Assert.Contains($"%24time=06%3A00%3A00", requestInfo.URI.OriginalString);
+        }
+        [Fact]
+        public void CurrentCultureDoesNotAffectTimeSerialization()
+        {
+            // Arrange as the request builders would
+            var requestInfo = new RequestInformation
+            {
+                HttpMethod = Method.GET,
+                UrlTemplate = "http://localhost/users{?%24time}"
+            };
+
+            var currentCulture = CultureInfo.CurrentCulture;
+            var currentUICulture = CultureInfo.CurrentUICulture;
+
+            // Act
+            Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("da-DK");
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo("da-DK");
+            var time = new Time(6, 0, 0);
+            var pathParameters = new Dictionary<string, object>
+            {
+                { "%24time", time }
+            };
+
+            requestInfo.PathParameters = pathParameters;
+
+            // Assert
+            Assert.Contains($"%24time=06%3A00%3A00", requestInfo.URI.OriginalString);
+
+            // Cleanup
+            Thread.CurrentThread.CurrentCulture = currentCulture;
+            Thread.CurrentThread.CurrentUICulture = currentUICulture;
         }
         [Fact]
         public void ThrowsInvalidOperationExceptionWhenBaseUrlNotSet()

--- a/src/Microsoft.Kiota.Abstractions.csproj
+++ b/src/Microsoft.Kiota.Abstractions.csproj
@@ -15,7 +15,7 @@
     <PackageProjectUrl>https://aka.ms/kiota/docs</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.9.2</VersionPrefix>
+    <VersionPrefix>1.9.3</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <SignAssembly>false</SignAssembly>

--- a/src/Time.cs
+++ b/src/Time.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Kiota.Abstractions
         /// <returns>The string time of day.</returns>
         public override string ToString()
         {
-            return this.DateTime.ToString("HH:mm:ss");
+            return this.DateTime.ToString("HH\\:mm\\:ss");
         }
     }
 }


### PR DESCRIPTION
it's either escaping with backslash to opt-out of colon's "special meanings" or explicitly specifying second argument `CultureInfo.GetCultureInfo("en-US")` to prevent it from rendering other separators.

see https://github.com/dotnet/runtime/issues/90300 and https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings#timeSeparator

took me three hours to figure out why the heck a test fails on one machine but not on the other..