### PR TITLE
chore(deps): bump Std.UriTemplate from 2.0.1 to 2.0.5 in Microsoft.Kiota.Abstractions

### DIFF
--- a/src/abstractions/Microsoft.Kiota.Abstractions.csproj
+++ b/src/abstractions/Microsoft.Kiota.Abstractions.csproj
@@ -14,7 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Std.UriTemplate" Version="2.0.1" />
+    <PackageReference Include="Std.UriTemplate" Version="2.0.5" />
   </ItemGroup>
 
   <!-- NET 5 target to be removed on next major version-->


### PR DESCRIPTION
Fixes #542 