### PR TITLE
Fix flaky observability tests due to parallel test interference

### DIFF
--- a/tests/http/httpClient/HttpClientRequestAdapterObservabilityTests.cs
+++ b/tests/http/httpClient/HttpClientRequestAdapterObservabilityTests.cs
@@ -425,7 +425,7 @@ public sealed class HttpClientRequestAdapterObservabilityTests : IDisposable
 
         // Assert - Verify various nested spans are created
         var resultingActivities = new HashSet<string>(
-            _capturedActivities.Where(a => a.TraceId == testRoot.TraceId).Select(static a => a.OperationName),
+            _capturedActivities.ToList().Where(a => a.TraceId == testRoot.TraceId).Select(static a => a.OperationName),
             StringComparer.Ordinal);
         Assert.Contains("SendAsync - {+baseurl}/users", resultingActivities);
         Assert.Contains("GetHttpResponseMessageAsync", resultingActivities);


### PR DESCRIPTION
## Summary

Fixes #658

The `HttpClientRequestAdapterObservabilityTests` were flaky when run as part of the full solution test suite due to parallel test interference. The `ActivityListener` captured activities from **all** Kiota sources globally, so activities from parallel test classes (e.g. `RequestAdapterTests`) leaked into `_capturedActivities`, causing intermittent assertion failures.

## Changes

- Added `StartTestRootActivity()` helper that creates a parent `Activity` with **W3C ID format** (required for .NET Framework 4.6.2 compatibility where the default is hierarchical format with empty `TraceId`)
- Each async test method now starts a root activity before calling `adapter.SendAsync()` — all child activities inherit its `TraceId`
- Updated `GetTagFromActivities()` to accept an `ActivityTraceId` parameter for filtering
- All assertions now filter `_capturedActivities` by the test's `TraceId`, ensuring complete isolation from parallel tests

## Validation

- Full solution tests pass consistently on both **net9.0** (261 tests) and **net462** (260 tests)
- Multiple consecutive runs confirmed stability