### PR TITLE
Added net10-browser as a target to enable the BROWSER directive

### DIFF
--- a/src/http/httpClient/Microsoft.Kiota.Http.HttpClientLibrary.csproj
+++ b/src/http/httpClient/Microsoft.Kiota.Http.HttpClientLibrary.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Kiota Http provider implementation for dotnet with HttpClient.</Description>
     <AssemblyTitle>Kiota Http Library for dotnet</AssemblyTitle>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net10.0;net462;net8.0-browser</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net10.0;net462;net8.0-browser;net10.0-browser</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <EnablePackageValidation>true</EnablePackageValidation>
     <GenerateCompatibilitySuppressionFile>false</GenerateCompatibilitySuppressionFile>


### PR DESCRIPTION
Fixes a regression born from the upgrade to net10 as described [here](https://github.com/microsoft/kiota-dotnet/issues/481#issuecomment-4810069334)