### PR TITLE
Route NuGet restore through the CFS central package feed

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -82,6 +82,20 @@ extends:
                   checkLatest: true
 
               # Build the Product project
+              - task: NuGetAuthenticate@1
+                displayName: 'Authenticate to Azure Artifacts'
+
+              - pwsh: |
+                  @"
+                  <?xml version="1.0" encoding="utf-8"?>
+                  <configuration>
+                    <packageSources>
+                      <clear />
+                      <add key="GraphDeveloperExperiences_Public" value="https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/nuget/v3/index.json" />
+                    </packageSources>
+                  </configuration>
+                  "@ | Set-Content -Path "$(Build.SourcesDirectory)/nuget.config" -Encoding UTF8
+                displayName: 'Create nuget.config (central feed)'
               - task: DotNetCoreCLI@2
                 displayName: "Build projects in Microsoft.Kiota"
                 inputs:


### PR DESCRIPTION
Routes CI package restore through the authenticated `GraphDeveloperExperiences_Public` Azure Artifacts feed (network isolation / CFS compliance). Adds `NuGetAuthenticate@1` + a generated `nuget.config`. Needs a pipeline run to validate.