### PR TITLE
fix(ci): gate release deploy on tag ref instead of main branch

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -65,7 +65,7 @@ extends:
 
               - task: PowerShell@2
                 displayName: "Validate project version has been incremented"
-                condition: and(contains(variables['build.sourceBranch'], 'refs/heads/main'),
+                condition: and(startsWith(variables['build.sourceBranch'], 'refs/tags/v'),
                   succeeded())
                 inputs:
                   targetType: "filePath"
@@ -244,7 +244,7 @@ extends:
 
               - task: CopyFiles@2
                 displayName: "Copy release scripts to artifact staging directory"
-                condition: and(contains(variables['build.sourceBranch'], 'refs/heads/main'),
+                condition: and(startsWith(variables['build.sourceBranch'], 'refs/tags/v'),
                   succeeded())
                 inputs:
                   SourceFolder: "$(Build.SourcesDirectory)"
@@ -252,7 +252,7 @@ extends:
                   TargetFolder: "$(Build.ArtifactStagingDirectory)"
 
       - stage: deploy
-        condition: and(contains(variables['build.sourceBranch'], 'refs/heads/main'),
+        condition: and(startsWith(variables['build.sourceBranch'], 'refs/tags/v'),
           succeeded())
         dependsOn: build
         jobs:


### PR DESCRIPTION
## Problem

The release runs for **2.0.1** and **2.0.2** built successfully but never actually published the packages. The `deploy` stage (NuGet push + GitHub release) was silently skipped due to a condition mismatch.

## Root cause

PR #714 (`dfcf159`, "modify CI pipeline to exclude branch triggers") switched the release trigger from the `main` branch to **`v*` tags only**:

```yaml
trigger:
  branches:
    exclude: ['*']
  tags:
    include: ["v*"]   # e.g. v2.0.2
```

However, three conditions were left gating on the old branch ref:

```yaml
condition: and(contains(variables['build.sourceBranch'], 'refs/heads/main'), succeeded())
```

On a tag-triggered run, `Build.SourceBranch` is `refs/tags/v2.0.2`, so `contains(..., 'refs/heads/main')` is **always false**. That skipped:

1. **`deploy` stage** → no NuGet push, no GitHub release (the actual shipping steps).
2. "Copy release scripts to artifact staging directory" → scripts wouldn't be in the artifact for deploy.
3. "Validate project version has been incremented".

The build stage still succeeded, which is why the runs looked green.

## Fix

Update the three conditions to match tag builds:

```yaml
condition: and(startsWith(variables['build.sourceBranch'], 'refs/tags/v'), succeeded())
```

## Notes / follow-up

- Since the deploy stage never ran, 2.0.1 and 2.0.2 are not on NuGet. After this merges, a fresh `v2.0.2` tag push will now hit the deploy stage and publish. `GetNugetPackageVersion.ps1` derives the version from the packed `.nupkg` (i.e. `Directory.Build.props`), not the tag, so the tag only needs to trigger the run.