### PR TITLE
ci: enable merge_group trigger for PR check workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches: [ "main", "dev" ]
   merge_group:
+    branches: [ "main", "dev" ]
 
 permissions:
   contents: read #those permissions are required to run the codeql analysis

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,6 +6,7 @@ on:
     branches: [ "main", "dev", "feature/*" ]
   pull_request:
     branches: [ "main", "dev" ]
+  merge_group:
 
 permissions:
   contents: read #those permissions are required to run the codeql analysis

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore: [".vscode/**"]
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -9,6 +9,8 @@ on:
     types: [opened, synchronize, reopened]
     paths-ignore: [".vscode/**"]
   merge_group:
+    branches:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Adds a `merge_group:` trigger to the PR CI check workflows so their required status checks run when a PR is queued in the merge queue.

## Changes

- **`build-and-test.yml`** — added `merge_group:` trigger
- **`sonarcloud.yml`** — added `merge_group:` trigger

## Notes

Only the workflows that produce required PR status checks were updated. The other PR-related workflows were intentionally left unchanged, since they are event-driven automations that act on the PR object itself and have no meaning in a merge group:

- `auto-merge-dependabot.yml` (enables auto-merge on Dependabot PRs)
- `conflicting-pr-label.yml` (labels conflicting PRs)
- `project-auto-add.yml` (adds opened PRs/issues to a project board)