### PR TITLE
ci(dependabot): add cooldown default delay

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,37 +1,37 @@
 version: 2
 updates:
-- package-ecosystem: nuget
-  directories:
-  - '**/*'
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  labels:
-  - dependencies
-  groups:
-    xunit:
-      patterns:
-      - xunit*
-    coverlet:
-      patterns:
-      - coverlet*
-  cooldown:
-    default-days: 7
-- package-ecosystem: github-actions
-  directory: /
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  cooldown:
-    default-days: 7
-- package-ecosystem: dotnet-sdk
-  directory: /
-  schedule:
-    interval: daily
-  ignore:
-  - dependency-name: '*'
-    update-types:
-    - version-update:semver-major
-    - version-update:semver-minor
-  cooldown:
-    default-days: 7
+  - package-ecosystem: nuget
+    directories:
+      - "**/*"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    groups:
+      xunit:
+        patterns:
+          - xunit*
+      coverlet:
+        patterns:
+          - coverlet*
+    cooldown:
+      default-days: 7
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+  - package-ecosystem: dotnet-sdk
+    directory: /
+    schedule:
+      interval: daily
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,34 +1,37 @@
 version: 2
 updates:
-  - package-ecosystem: nuget
-    directories:
-      - "**/*"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-    labels:
-      - dependencies
-    groups:
-      xunit:
-        patterns:
-          - xunit*
-      coverlet:
-        patterns:
-          - coverlet*
-  - package-ecosystem: github-actions
-    directory: "/"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-    cooldown:
-      default-days: 7
-
-  - package-ecosystem: dotnet-sdk
-    directory: /
-    schedule:
-      interval: "daily"
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - version-update:semver-major
-          - version-update:semver-minor
+- package-ecosystem: nuget
+  directories:
+  - '**/*'
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  labels:
+  - dependencies
+  groups:
+    xunit:
+      patterns:
+      - xunit*
+    coverlet:
+      patterns:
+      - coverlet*
+  cooldown:
+    default-days: 7
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  cooldown:
+    default-days: 7
+- package-ecosystem: dotnet-sdk
+  directory: /
+  schedule:
+    interval: daily
+  ignore:
+  - dependency-name: '*'
+    update-types:
+    - version-update:semver-major
+    - version-update:semver-minor
+  cooldown:
+    default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,10 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action*"
   - package-ecosystem: dotnet-sdk
     directory: /
     schedule:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,6 @@
 {
-	"cSpell.words": [
-		"Kiota"
-	],
-	"editor.formatOnSave": true,
-	"dotnet-test-explorer.testProjectPath": "**/*.Tests.csproj",
-	"sarif-viewer.connectToGithubCodeScanning": "on"
+  "cSpell.words": ["cooldown", "Kiota"],
+  "editor.formatOnSave": true,
+  "dotnet-test-explorer.testProjectPath": "**/*.Tests.csproj",
+  "sarif-viewer.connectToGithubCodeScanning": "on"
 }


### PR DESCRIPTION
Adds a 7-day default Dependabot cooldown so CIF deployment has time to complete before dependency update PRs are opened.

This helps avoid getting ahead with versions before they are fully available through deployment.